### PR TITLE
[Feat] 설정화면 Compose 마이그레이션

### DIFF
--- a/app/src/main/java/com/daedan/festabook/presentation/common/component/FestabookSwitch.kt
+++ b/app/src/main/java/com/daedan/festabook/presentation/common/component/FestabookSwitch.kt
@@ -1,0 +1,33 @@
+package com.daedan.festabook.presentation.common.component
+
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.material3.Switch
+import androidx.compose.material3.SwitchDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import com.daedan.festabook.presentation.theme.FestabookColor
+
+@Composable
+fun FestabookSwitch(
+    enabled: Boolean,
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Switch(
+        enabled = enabled,
+        modifier = modifier.wrapContentSize(),
+        checked = checked,
+        onCheckedChange = onCheckedChange,
+        colors =
+            SwitchDefaults.colors().copy(
+                checkedBorderColor = Color.Transparent,
+                uncheckedBorderColor = Color.Transparent,
+                disabledCheckedTrackColor = FestabookColor.black,
+                disabledUncheckedTrackColor = FestabookColor.gray200,
+                checkedTrackColor = FestabookColor.black,
+                uncheckedTrackColor = FestabookColor.gray200,
+            ),
+    )
+}

--- a/app/src/main/java/com/daedan/festabook/presentation/common/component/ObserveAsEvents.kt
+++ b/app/src/main/java/com/daedan/festabook/presentation/common/component/ObserveAsEvents.kt
@@ -1,0 +1,27 @@
+package com.daedan.festabook.presentation.common.component
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.repeatOnLifecycle
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.withContext
+
+// MVI 리팩토링 PR에도 동일한 코드가 사용되어
+// 머지 시 해당 부분 제거하여 충돌을 해결하겠습니다.
+@Composable
+fun <T> ObserveAsEvents(
+    flow: Flow<T>,
+    onEvent: suspend (T) -> Unit,
+) {
+    val lifecycleOwner = LocalLifecycleOwner.current
+    LaunchedEffect(flow, lifecycleOwner.lifecycle) {
+        lifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+            withContext(Dispatchers.Main.immediate) {
+                flow.collect(onEvent)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/daedan/festabook/presentation/setting/SettingFragment.kt
+++ b/app/src/main/java/com/daedan/festabook/presentation/setting/SettingFragment.kt
@@ -2,13 +2,20 @@ package com.daedan.festabook.presentation.setting
 
 import android.content.Intent
 import android.os.Bundle
+import android.view.LayoutInflater
 import android.view.View
+import android.view.ViewGroup
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.core.net.toUri
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.daedan.festabook.BuildConfig
 import com.daedan.festabook.R
 import com.daedan.festabook.databinding.FragmentSettingBinding
@@ -16,10 +23,12 @@ import com.daedan.festabook.di.fragment.FragmentKey
 import com.daedan.festabook.presentation.NotificationPermissionManager
 import com.daedan.festabook.presentation.NotificationPermissionRequester
 import com.daedan.festabook.presentation.common.BaseFragment
+import com.daedan.festabook.presentation.common.component.ObserveAsEvents
 import com.daedan.festabook.presentation.common.showErrorSnackBar
 import com.daedan.festabook.presentation.common.showNotificationDeniedSnackbar
 import com.daedan.festabook.presentation.common.showSnackBar
 import com.daedan.festabook.presentation.home.HomeViewModel
+import com.daedan.festabook.presentation.setting.component.SettingScreen
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesIntoMap
 import dev.zacsweers.metro.Inject
@@ -58,7 +67,7 @@ class SettingFragment(
                 onPermissionGranted()
             } else {
                 Timber.d("Notification permission denied")
-                showNotificationDeniedSnackbar(binding.root, requireContext())
+                showNotificationDeniedSnackbar(view!!, requireContext())
                 onPermissionDenied()
             }
         }
@@ -69,87 +78,60 @@ class SettingFragment(
 
     override fun onPermissionDenied() = Unit
 
-    override fun onViewCreated(
-        view: View,
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
         savedInstanceState: Bundle?,
-    ) {
-        super.onViewCreated(view, savedInstanceState)
-        setupBindings()
+    ): View =
+        ComposeView(requireContext()).apply {
+            super.onCreateView(inflater, container, savedInstanceState)
+            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+            setContent {
+                val festival by homeViewModel.festivalUiState.collectAsStateWithLifecycle()
+                val isUniversitySubscribed by settingViewModel.isAllowed.collectAsStateWithLifecycle()
+                val isSubscribedLoading by settingViewModel.isLoading.collectAsStateWithLifecycle()
+                val context = LocalContext.current
 
-        setupNoticeAllowButtonClickListener()
-        setupServicePolicyClickListener()
-        setupContactUsButtonClickListener()
-        setupObservers()
-    }
+                ObserveAsEvents(flow = settingViewModel.permissionCheckEvent) {
+                    notificationPermissionManager.requestNotificationPermission(context)
+                }
 
-    private fun setupBindings() {
-        val versionName = BuildConfig.VERSION_NAME
-        binding.tvSettingAppVersionName.text = versionName
-    }
+                ObserveAsEvents(flow = settingViewModel.successFlow) {
+                    requireActivity().showSnackBar(getString(R.string.setting_notice_enabled))
+                }
+
+                ObserveAsEvents(flow = settingViewModel.error) {
+                    showErrorSnackBar(it)
+                }
+
+                SettingScreen(
+                    festivalUiState = festival,
+                    isUniversitySubscribed = isUniversitySubscribed,
+                    appVersion = BuildConfig.VERSION_NAME,
+                    isSubscribeEnabled = !isSubscribedLoading,
+                    onSubscribeClick = {
+                        settingViewModel.notificationAllowClick()
+                    },
+                    onPolicyClick = {
+                        val intent = Intent(Intent.ACTION_VIEW, POLICY_URL.toUri())
+                        startActivity(intent)
+                    },
+                    onContactUsClick = {
+                        val intent = Intent(Intent.ACTION_VIEW, CONTACT_US_URL.toUri())
+                        startActivity(intent)
+                    },
+                    onError = {
+                        showErrorSnackBar(it.throwable)
+                        Timber.w(
+                            it.throwable,
+                            "${this::class.simpleName}: ${it.throwable.message}",
+                        )
+                    },
+                )
+            }
+        }
 
     override fun shouldShowPermissionRationale(permission: String): Boolean = shouldShowRequestPermissionRationale(permission)
-
-    private fun setupObservers() {
-        settingViewModel.permissionCheckEvent.observe(viewLifecycleOwner) {
-            notificationPermissionManager.requestNotificationPermission(
-                requireContext(),
-            )
-        }
-        settingViewModel.isAllowed.observe(viewLifecycleOwner) {
-            binding.btnNoticeAllow.isChecked = it
-        }
-        settingViewModel.success.observe(viewLifecycleOwner) {
-            requireActivity().showSnackBar(getString(R.string.setting_notice_enabled))
-        }
-        settingViewModel.error.observe(viewLifecycleOwner) { throwable ->
-            showErrorSnackBar(throwable)
-        }
-        settingViewModel.isLoading.observe(viewLifecycleOwner) { loading ->
-            binding.btnNoticeAllow.isEnabled = !loading
-        }
-
-//        homeViewModel.festivalUiState.observe(viewLifecycleOwner) { state ->
-//            when (state) {
-//                is FestivalUiState.Error -> {
-//                    showErrorSnackBar(state.throwable)
-//                    Timber.w(
-//                        state.throwable,
-//                        "${this::class.simpleName}: ${state.throwable.message}",
-//                    )
-//                }
-//
-//                FestivalUiState.Loading -> {
-//                    binding.tvSettingCurrentUniversityNotice.text = ""
-//                }
-//
-//                is FestivalUiState.Success -> {
-//                    binding.tvSettingCurrentUniversity.text = state.organization.universityName
-//                }
-//            }
-//        }
-    }
-
-    private fun setupServicePolicyClickListener() {
-        binding.tvSettingServicePolicy.setOnClickListener {
-            val intent = Intent(Intent.ACTION_VIEW, POLICY_URL.toUri())
-            startActivity(intent)
-        }
-    }
-
-    private fun setupContactUsButtonClickListener() {
-        binding.tvSettingContactUs.setOnClickListener {
-            val intent = Intent(Intent.ACTION_VIEW, CONTACT_US_URL.toUri())
-            startActivity(intent)
-        }
-    }
-
-    private fun setupNoticeAllowButtonClickListener() {
-        binding.btnNoticeAllow.setOnClickListener {
-            // 기본적으로 클릭했을 때 checked되는 기능 무효화
-            binding.btnNoticeAllow.isChecked = !binding.btnNoticeAllow.isChecked
-            settingViewModel.notificationAllowClick()
-        }
-    }
 
     companion object {
         private const val POLICY_URL: String =

--- a/app/src/main/java/com/daedan/festabook/presentation/setting/SettingFragment.kt
+++ b/app/src/main/java/com/daedan/festabook/presentation/setting/SettingFragment.kt
@@ -67,7 +67,7 @@ class SettingFragment(
                 onPermissionGranted()
             } else {
                 Timber.d("Notification permission denied")
-                showNotificationDeniedSnackbar(view!!, requireContext())
+                showNotificationDeniedSnackbar(requireView(), requireContext())
                 onPermissionDenied()
             }
         }

--- a/app/src/main/java/com/daedan/festabook/presentation/setting/SettingViewModel.kt
+++ b/app/src/main/java/com/daedan/festabook/presentation/setting/SettingViewModel.kt
@@ -1,15 +1,20 @@
 package com.daedan.festabook.presentation.setting
 
 import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
 import com.daedan.festabook.di.viewmodel.ViewModelKey
 import com.daedan.festabook.domain.repository.FestivalNotificationRepository
-import com.daedan.festabook.presentation.common.SingleLiveData
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesIntoMap
 import dev.zacsweers.metro.Inject
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import timber.log.Timber
 
@@ -19,27 +24,37 @@ import timber.log.Timber
 class SettingViewModel(
     private val festivalNotificationRepository: FestivalNotificationRepository,
 ) : ViewModel() {
-    private val _permissionCheckEvent: SingleLiveData<Unit> = SingleLiveData()
-    val permissionCheckEvent: LiveData<Unit> get() = _permissionCheckEvent
+    private val _permissionCheckEvent: MutableSharedFlow<Unit> =
+        MutableSharedFlow(
+            replay = 1,
+        )
+    val permissionCheckEvent: SharedFlow<Unit> = _permissionCheckEvent.asSharedFlow()
 
     private val _isAllowed =
-        MutableLiveData(
+        MutableStateFlow(
             festivalNotificationRepository.getFestivalNotificationIsAllow(),
         )
-    val isAllowed: LiveData<Boolean> get() = _isAllowed
+    val isAllowed: StateFlow<Boolean> = _isAllowed.asStateFlow()
 
-    private val _error: SingleLiveData<Throwable> = SingleLiveData()
-    val error: LiveData<Throwable> get() = _error
+    private val _error: MutableSharedFlow<Throwable> =
+        MutableSharedFlow(
+            replay = 1,
+        )
+    val error: SharedFlow<Throwable> = _error.asSharedFlow()
 
-    private val _isLoading: MutableLiveData<Boolean> = MutableLiveData(false)
-    val isLoading: LiveData<Boolean> get() = _isLoading
+    private val _isLoading: MutableStateFlow<Boolean> = MutableStateFlow(false)
+    val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
 
-    private val _success: SingleLiveData<Unit> = SingleLiveData()
-    val success: LiveData<Unit> get() = _success
+    private val _success: MutableSharedFlow<Unit> =
+        MutableSharedFlow(
+            replay = 1,
+        )
+    val success: LiveData<Unit> = _success.asLiveData()
+    val successFlow = _success.asSharedFlow()
 
     fun notificationAllowClick() {
-        if (_isAllowed.value == false) {
-            _permissionCheckEvent.setValue(Unit)
+        if (!_isAllowed.value) {
+            _permissionCheckEvent.tryEmit(Unit)
         } else {
             deleteNotificationId()
         }
@@ -54,13 +69,13 @@ class SettingViewModel(
     }
 
     fun saveNotificationId() {
-        if (_isLoading.value == true) return
+        if (_isLoading.value) return
         _isLoading.value = true
 
         // Optimistic UI 적용, 요청 실패 시 원복
         saveNotificationIsAllowed(true)
         updateNotificationIsAllowed(true)
-        _success.setValue(Unit)
+        _success.tryEmit(Unit)
 
         viewModelScope.launch {
             val result =
@@ -68,7 +83,7 @@ class SettingViewModel(
 
             result
                 .onFailure {
-                    _error.setValue(it)
+                    _error.tryEmit(it)
                     saveNotificationIsAllowed(false)
                     updateNotificationIsAllowed(false)
                     Timber.e(it, "${this::class.java.simpleName} NotificationId 저장 실패")
@@ -79,7 +94,7 @@ class SettingViewModel(
     }
 
     private fun deleteNotificationId() {
-        if (_isLoading.value == true) return
+        if (_isLoading.value) return
         _isLoading.value = true
 
         // Optimistic UI 적용, 요청 실패 시 원복
@@ -92,7 +107,7 @@ class SettingViewModel(
 
             result
                 .onFailure {
-                    _error.setValue(it)
+                    _error.tryEmit(it)
                     saveNotificationIsAllowed(true)
                     updateNotificationIsAllowed(true)
                     Timber.e(it, "${this::class.java.simpleName} NotificationId 삭제 실패")

--- a/app/src/main/java/com/daedan/festabook/presentation/setting/SettingViewModel.kt
+++ b/app/src/main/java/com/daedan/festabook/presentation/setting/SettingViewModel.kt
@@ -25,9 +25,7 @@ class SettingViewModel(
     private val festivalNotificationRepository: FestivalNotificationRepository,
 ) : ViewModel() {
     private val _permissionCheckEvent: MutableSharedFlow<Unit> =
-        MutableSharedFlow(
-            replay = 1,
-        )
+        MutableSharedFlow()
     val permissionCheckEvent: SharedFlow<Unit> = _permissionCheckEvent.asSharedFlow()
 
     private val _isAllowed =
@@ -37,24 +35,22 @@ class SettingViewModel(
     val isAllowed: StateFlow<Boolean> = _isAllowed.asStateFlow()
 
     private val _error: MutableSharedFlow<Throwable> =
-        MutableSharedFlow(
-            replay = 1,
-        )
+        MutableSharedFlow()
     val error: SharedFlow<Throwable> = _error.asSharedFlow()
 
     private val _isLoading: MutableStateFlow<Boolean> = MutableStateFlow(false)
     val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
 
     private val _success: MutableSharedFlow<Unit> =
-        MutableSharedFlow(
-            replay = 1,
-        )
+        MutableSharedFlow()
     val success: LiveData<Unit> = _success.asLiveData()
     val successFlow = _success.asSharedFlow()
 
     fun notificationAllowClick() {
         if (!_isAllowed.value) {
-            _permissionCheckEvent.tryEmit(Unit)
+            viewModelScope.launch {
+                _permissionCheckEvent.emit(Unit)
+            }
         } else {
             deleteNotificationId()
         }
@@ -75,15 +71,16 @@ class SettingViewModel(
         // Optimistic UI 적용, 요청 실패 시 원복
         saveNotificationIsAllowed(true)
         updateNotificationIsAllowed(true)
-        _success.tryEmit(Unit)
 
         viewModelScope.launch {
+            _success.emit(Unit)
+
             val result =
                 festivalNotificationRepository.saveFestivalNotification()
 
             result
                 .onFailure {
-                    _error.tryEmit(it)
+                    _error.emit(it)
                     saveNotificationIsAllowed(false)
                     updateNotificationIsAllowed(false)
                     Timber.e(it, "${this::class.java.simpleName} NotificationId 저장 실패")
@@ -107,7 +104,7 @@ class SettingViewModel(
 
             result
                 .onFailure {
-                    _error.tryEmit(it)
+                    _error.emit(it)
                     saveNotificationIsAllowed(true)
                     updateNotificationIsAllowed(true)
                     Timber.e(it, "${this::class.java.simpleName} NotificationId 삭제 실패")

--- a/app/src/main/java/com/daedan/festabook/presentation/setting/component/SettingScreen.kt
+++ b/app/src/main/java/com/daedan/festabook/presentation/setting/component/SettingScreen.kt
@@ -1,9 +1,11 @@
 package com.daedan.festabook.presentation.setting.component
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.requiredWidth
@@ -15,9 +17,11 @@ import androidx.compose.material3.Switch
 import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -30,21 +34,27 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.daedan.festabook.R
-import com.daedan.festabook.presentation.common.component.Header
+import com.daedan.festabook.domain.model.Festival
+import com.daedan.festabook.domain.model.Organization
+import com.daedan.festabook.presentation.common.component.FestabookTopAppBar
+import com.daedan.festabook.presentation.home.adapter.FestivalUiState
 import com.daedan.festabook.presentation.theme.FestabookColor
 import com.daedan.festabook.presentation.theme.FestabookTheme
 import com.daedan.festabook.presentation.theme.FestabookTypography
 import com.daedan.festabook.presentation.theme.festabookSpacing
+import java.time.LocalDate
 
 @Composable
 fun SettingScreen(
-    universityName: String,
+    festivalUiState: FestivalUiState,
     isUniversitySubscribed: Boolean,
     appVersion: String,
+    isSubscribeEnabled: Boolean,
     modifier: Modifier = Modifier,
     onSubscribeClick: (Boolean) -> Unit = {},
     onPolicyClick: () -> Unit = {},
     onContactUsClick: () -> Unit = {},
+    onError: (FestivalUiState.Error) -> Unit = {},
 ) {
     val windowInfo = LocalWindowInfo.current
     val density = LocalDensity.current
@@ -52,10 +62,18 @@ fun SettingScreen(
         with(density) {
             windowInfo.containerSize.width.toDp()
         }
+    val currentOnError by rememberUpdatedState(onError)
+
+    LaunchedEffect(festivalUiState) {
+        when (festivalUiState) {
+            is FestivalUiState.Error -> currentOnError(festivalUiState)
+            else -> Unit
+        }
+    }
 
     Scaffold(
         topBar = {
-            Header(
+            FestabookTopAppBar(
                 title = stringResource(R.string.setting_title),
             )
         },
@@ -64,14 +82,23 @@ fun SettingScreen(
         Column(
             modifier =
                 Modifier
+                    .fillMaxSize()
+                    .background(color = FestabookColor.white)
                     .padding(horizontal = festabookSpacing.paddingScreenGutter)
                     .padding(innerPadding),
         ) {
-            SubscriptionContent(
-                universityName = universityName,
-                isUniversitySubscribed = isUniversitySubscribed,
-                onSubscribeClick = onSubscribeClick,
-            )
+            when (festivalUiState) {
+                is FestivalUiState.Success -> {
+                    SubscriptionContent(
+                        universityName = festivalUiState.organization.universityName,
+                        isUniversitySubscribed = isUniversitySubscribed,
+                        onSubscribeClick = onSubscribeClick,
+                        isSubscribeEnabled = isSubscribeEnabled,
+                    )
+                }
+
+                else -> Unit
+            }
 
             HorizontalDivider(
                 modifier =
@@ -86,6 +113,7 @@ fun SettingScreen(
                 appVersion = appVersion,
                 onPolicyClick = onPolicyClick,
                 onContactUsClick = onContactUsClick,
+                modifier = Modifier.background(color = FestabookColor.white),
             )
         }
     }
@@ -95,6 +123,7 @@ fun SettingScreen(
 private fun SubscriptionContent(
     universityName: String,
     isUniversitySubscribed: Boolean,
+    isSubscribeEnabled: Boolean,
     onSubscribeClick: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -134,6 +163,7 @@ private fun SubscriptionContent(
             }
 
             Switch(
+                enabled = isSubscribeEnabled,
                 modifier = Modifier.wrapContentSize(),
                 checked = isUniversitySubscribed,
                 onCheckedChange = onSubscribeClick,
@@ -141,8 +171,8 @@ private fun SubscriptionContent(
                     SwitchDefaults.colors().copy(
                         checkedBorderColor = Color.Transparent,
                         uncheckedBorderColor = Color.Transparent,
-                        disabledCheckedBorderColor = Color.Transparent,
-                        disabledUncheckedBorderColor = Color.Transparent,
+                        disabledCheckedTrackColor = FestabookColor.black,
+                        disabledUncheckedTrackColor = FestabookColor.gray200,
                         checkedTrackColor = FestabookColor.black,
                         uncheckedTrackColor = FestabookColor.gray200,
                     ),
@@ -249,10 +279,24 @@ private fun SettingScreenPreview() {
     FestabookTheme {
         var isSubscribed by remember { mutableStateOf(false) }
         SettingScreen(
-            universityName = "성균관대학교 인문사회과학철학문학자연캠퍼스 인문사회과학철학문학자연캠퍼스",
+            festivalUiState =
+                FestivalUiState.Success(
+                    Organization(
+                        id = 1,
+                        universityName = "성균관대학교 인문사회과학철학문학자연캠퍼스 인문사회과학철학문학자연캠퍼스",
+                        festival =
+                            Festival(
+                                festivalName = "성균관대학교 축제축제축제축제축제축제축제축제축제축제축제축제",
+                                festivalImages = listOf(),
+                                startDate = LocalDate.of(2026, 1, 1),
+                                endDate = LocalDate.of(2026, 2, 1),
+                            ),
+                    ),
+                ),
             isUniversitySubscribed = isSubscribed,
             onSubscribeClick = { isSubscribed = !isSubscribed },
             appVersion = "v1.0.0",
+            isSubscribeEnabled = true,
         )
     }
 }

--- a/app/src/main/java/com/daedan/festabook/presentation/setting/component/SettingScreen.kt
+++ b/app/src/main/java/com/daedan/festabook/presentation/setting/component/SettingScreen.kt
@@ -59,9 +59,12 @@ fun SettingScreen(
     val windowInfo = LocalWindowInfo.current
     val density = LocalDensity.current
     val screenWidthDp =
-        with(density) {
-            windowInfo.containerSize.width.toDp()
+        remember {
+            with(density) {
+                windowInfo.containerSize.width.toDp()
+            }
         }
+
     val currentOnError by rememberUpdatedState(onError)
 
     LaunchedEffect(festivalUiState) {
@@ -188,13 +191,6 @@ private fun AppInfoContent(
     onContactUsClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val windowInfo = LocalWindowInfo.current
-    val density = LocalDensity.current
-    val screenWidthDp =
-        with(density) {
-            windowInfo.containerSize.width.toDp()
-        }
-
     Column(modifier = modifier) {
         Text(
             text = stringResource(R.string.setting_app_info_title),
@@ -202,74 +198,84 @@ private fun AppInfoContent(
             style = FestabookTypography.bodyMedium,
         )
 
-        Row(
-            horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.CenterVertically,
-            modifier =
-                Modifier
-                    .fillMaxWidth()
-                    .padding(vertical = festabookSpacing.paddingBody3),
-        ) {
-            Text(
-                text = stringResource(R.string.setting_app_version),
-                style = FestabookTypography.titleMedium,
-            )
+        AppVersionInfo(
+            appVersion = appVersion,
+        )
 
-            Text(
-                text = appVersion,
-                style = FestabookTypography.bodyMedium,
-            )
+        AppInfoButton(
+            text = stringResource(R.string.setting_service_policy),
+            onClick = onPolicyClick,
+        )
+        AppInfoButton(
+            text = stringResource(R.string.setting_contact_us),
+            onClick = onContactUsClick,
+        )
+    }
+}
+
+@Composable
+private fun AppVersionInfo(
+    appVersion: String,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .padding(vertical = festabookSpacing.paddingBody3),
+    ) {
+        Text(
+            text = stringResource(R.string.setting_app_version),
+            style = FestabookTypography.titleMedium,
+        )
+
+        Text(
+            text = appVersion,
+            style = FestabookTypography.bodyMedium,
+        )
+    }
+}
+
+@Composable
+private fun AppInfoButton(
+    text: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val windowInfo = LocalWindowInfo.current
+    val density = LocalDensity.current
+    val screenWidthDp =
+        remember {
+            with(density) {
+                windowInfo.containerSize.width.toDp()
+            }
         }
 
-        Row(
-            horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.CenterVertically,
-            modifier =
-                Modifier
-                    .requiredWidth(screenWidthDp)
-                    .clickable {
-                        onPolicyClick()
-                    }.padding(
-                        horizontal = festabookSpacing.paddingScreenGutter,
-                        vertical = festabookSpacing.paddingBody3,
-                    ),
-        ) {
-            Text(
-                text = stringResource(R.string.setting_service_policy),
-                style = FestabookTypography.titleMedium,
-            )
+    Row(
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+        modifier =
+            modifier
+                .requiredWidth(screenWidthDp)
+                .clickable {
+                    onClick()
+                }.padding(
+                    horizontal = festabookSpacing.paddingScreenGutter,
+                    vertical = festabookSpacing.paddingBody3,
+                ),
+    ) {
+        Text(
+            text = text,
+            style = FestabookTypography.titleMedium,
+        )
 
-            Icon(
-                painter = painterResource(R.drawable.ic_arrow_forward_right),
-                contentDescription = stringResource(R.string.move),
-                tint = Color.Unspecified,
-            )
-        }
-
-        Row(
-            horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.CenterVertically,
-            modifier =
-                Modifier
-                    .requiredWidth(screenWidthDp)
-                    .clickable {
-                        onContactUsClick()
-                    }.padding(
-                        horizontal = festabookSpacing.paddingScreenGutter,
-                        vertical = festabookSpacing.paddingBody3,
-                    ),
-        ) {
-            Text(
-                text = stringResource(R.string.setting_contact_us),
-                style = FestabookTypography.titleMedium,
-            )
-
-            Icon(
-                painter = painterResource(R.drawable.ic_arrow_forward_right),
-                contentDescription = stringResource(R.string.move),
-                tint = Color.Unspecified,
-            )
-        }
+        Icon(
+            painter = painterResource(R.drawable.ic_arrow_forward_right),
+            contentDescription = stringResource(R.string.move),
+            tint = Color.Unspecified,
+        )
     }
 }
 

--- a/app/src/main/java/com/daedan/festabook/presentation/setting/component/SettingScreen.kt
+++ b/app/src/main/java/com/daedan/festabook/presentation/setting/component/SettingScreen.kt
@@ -1,0 +1,258 @@
+package com.daedan.festabook.presentation.setting.component
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.requiredWidth
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Switch
+import androidx.compose.material3.SwitchDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalWindowInfo
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.daedan.festabook.R
+import com.daedan.festabook.presentation.common.component.Header
+import com.daedan.festabook.presentation.theme.FestabookColor
+import com.daedan.festabook.presentation.theme.FestabookTheme
+import com.daedan.festabook.presentation.theme.FestabookTypography
+import com.daedan.festabook.presentation.theme.festabookSpacing
+
+@Composable
+fun SettingScreen(
+    universityName: String,
+    isUniversitySubscribed: Boolean,
+    appVersion: String,
+    modifier: Modifier = Modifier,
+    onSubscribeClick: (Boolean) -> Unit = {},
+    onPolicyClick: () -> Unit = {},
+    onContactUsClick: () -> Unit = {},
+) {
+    val windowInfo = LocalWindowInfo.current
+    val density = LocalDensity.current
+    val screenWidthDp =
+        with(density) {
+            windowInfo.containerSize.width.toDp()
+        }
+
+    Scaffold(
+        topBar = {
+            Header(
+                title = stringResource(R.string.setting_title),
+            )
+        },
+        modifier = modifier,
+    ) { innerPadding ->
+        Column(
+            modifier =
+                Modifier
+                    .padding(horizontal = festabookSpacing.paddingScreenGutter)
+                    .padding(innerPadding),
+        ) {
+            SubscriptionContent(
+                universityName = universityName,
+                isUniversitySubscribed = isUniversitySubscribed,
+                onSubscribeClick = onSubscribeClick,
+            )
+
+            HorizontalDivider(
+                modifier =
+                    Modifier
+                        .requiredWidth(screenWidthDp)
+                        .padding(vertical = 20.dp),
+                color = FestabookColor.gray100,
+                thickness = festabookSpacing.paddingBody2,
+            )
+
+            AppInfoContent(
+                appVersion = appVersion,
+                onPolicyClick = onPolicyClick,
+                onContactUsClick = onContactUsClick,
+            )
+        }
+    }
+}
+
+@Composable
+private fun SubscriptionContent(
+    universityName: String,
+    isUniversitySubscribed: Boolean,
+    onSubscribeClick: (Boolean) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier) {
+        Text(
+            text = stringResource(R.string.setting_notice_title),
+            style = FestabookTypography.bodyMedium,
+            modifier = Modifier.padding(top = 20.dp),
+        )
+
+        Row(
+            modifier = Modifier.wrapContentSize(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            Column(
+                modifier = Modifier.weight(1f),
+            ) {
+                Text(
+                    text = stringResource(R.string.setting_current_university_notice),
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    style = FestabookTypography.titleMedium,
+                    modifier =
+                        Modifier.padding(
+                            top = festabookSpacing.paddingBody3,
+                        ),
+                )
+
+                Text(
+                    text = universityName,
+                    style = FestabookTypography.bodyMedium,
+                    modifier = Modifier.padding(vertical = festabookSpacing.paddingBody1),
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    color = FestabookColor.gray500,
+                )
+            }
+
+            Switch(
+                modifier = Modifier.wrapContentSize(),
+                checked = isUniversitySubscribed,
+                onCheckedChange = onSubscribeClick,
+                colors =
+                    SwitchDefaults.colors().copy(
+                        checkedBorderColor = Color.Transparent,
+                        uncheckedBorderColor = Color.Transparent,
+                        disabledCheckedBorderColor = Color.Transparent,
+                        disabledUncheckedBorderColor = Color.Transparent,
+                        checkedTrackColor = FestabookColor.black,
+                        uncheckedTrackColor = FestabookColor.gray200,
+                    ),
+            )
+        }
+    }
+}
+
+@Composable
+private fun AppInfoContent(
+    appVersion: String,
+    onPolicyClick: () -> Unit,
+    onContactUsClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val windowInfo = LocalWindowInfo.current
+    val density = LocalDensity.current
+    val screenWidthDp =
+        with(density) {
+            windowInfo.containerSize.width.toDp()
+        }
+
+    Column(modifier = modifier) {
+        Text(
+            text = stringResource(R.string.setting_app_info_title),
+            modifier = Modifier.padding(vertical = festabookSpacing.paddingBody3),
+            style = FestabookTypography.bodyMedium,
+        )
+
+        Row(
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = festabookSpacing.paddingBody3),
+        ) {
+            Text(
+                text = stringResource(R.string.setting_app_version),
+                style = FestabookTypography.titleMedium,
+            )
+
+            Text(
+                text = appVersion,
+                style = FestabookTypography.bodyMedium,
+            )
+        }
+
+        Row(
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+            modifier =
+                Modifier
+                    .requiredWidth(screenWidthDp)
+                    .clickable {
+                        onPolicyClick()
+                    }.padding(
+                        horizontal = festabookSpacing.paddingScreenGutter,
+                        vertical = festabookSpacing.paddingBody3,
+                    ),
+        ) {
+            Text(
+                text = stringResource(R.string.setting_service_policy),
+                style = FestabookTypography.titleMedium,
+            )
+
+            Icon(
+                painter = painterResource(R.drawable.ic_arrow_forward_right),
+                contentDescription = stringResource(R.string.move),
+                tint = Color.Unspecified,
+            )
+        }
+
+        Row(
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+            modifier =
+                Modifier
+                    .requiredWidth(screenWidthDp)
+                    .clickable {
+                        onContactUsClick()
+                    }.padding(
+                        horizontal = festabookSpacing.paddingScreenGutter,
+                        vertical = festabookSpacing.paddingBody3,
+                    ),
+        ) {
+            Text(
+                text = stringResource(R.string.setting_contact_us),
+                style = FestabookTypography.titleMedium,
+            )
+
+            Icon(
+                painter = painterResource(R.drawable.ic_arrow_forward_right),
+                contentDescription = stringResource(R.string.move),
+                tint = Color.Unspecified,
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun SettingScreenPreview() {
+    FestabookTheme {
+        var isSubscribed by remember { mutableStateOf(false) }
+        SettingScreen(
+            universityName = "성균관대학교 인문사회과학철학문학자연캠퍼스 인문사회과학철학문학자연캠퍼스",
+            isUniversitySubscribed = isSubscribed,
+            onSubscribeClick = { isSubscribed = !isSubscribed },
+            appVersion = "v1.0.0",
+        )
+    }
+}

--- a/app/src/main/java/com/daedan/festabook/presentation/setting/component/SettingScreen.kt
+++ b/app/src/main/java/com/daedan/festabook/presentation/setting/component/SettingScreen.kt
@@ -115,7 +115,6 @@ fun SettingScreen(
                 appVersion = appVersion,
                 onPolicyClick = onPolicyClick,
                 onContactUsClick = onContactUsClick,
-                modifier = Modifier.background(color = FestabookColor.white),
             )
         }
     }

--- a/app/src/main/java/com/daedan/festabook/presentation/setting/component/SettingScreen.kt
+++ b/app/src/main/java/com/daedan/festabook/presentation/setting/component/SettingScreen.kt
@@ -13,8 +13,6 @@ import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Switch
-import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -36,6 +34,7 @@ import androidx.compose.ui.unit.dp
 import com.daedan.festabook.R
 import com.daedan.festabook.domain.model.Festival
 import com.daedan.festabook.domain.model.Organization
+import com.daedan.festabook.presentation.common.component.FestabookSwitch
 import com.daedan.festabook.presentation.common.component.FestabookTopAppBar
 import com.daedan.festabook.presentation.home.adapter.FestivalUiState
 import com.daedan.festabook.presentation.theme.FestabookColor
@@ -165,20 +164,10 @@ private fun SubscriptionContent(
                 )
             }
 
-            Switch(
+            FestabookSwitch(
                 enabled = isSubscribeEnabled,
-                modifier = Modifier.wrapContentSize(),
                 checked = isUniversitySubscribed,
                 onCheckedChange = onSubscribeClick,
-                colors =
-                    SwitchDefaults.colors().copy(
-                        checkedBorderColor = Color.Transparent,
-                        uncheckedBorderColor = Color.Transparent,
-                        disabledCheckedTrackColor = FestabookColor.black,
-                        disabledUncheckedTrackColor = FestabookColor.gray200,
-                        checkedTrackColor = FestabookColor.black,
-                        uncheckedTrackColor = FestabookColor.gray200,
-                    ),
             )
         }
     }

--- a/app/src/test/java/com/daedan/festabook/FlowExtension.kt
+++ b/app/src/test/java/com/daedan/festabook/FlowExtension.kt
@@ -1,0 +1,41 @@
+package com.daedan.festabook
+
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.timeout
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.withTimeout
+import kotlin.time.Duration.Companion.seconds
+
+@OptIn(ExperimentalCoroutinesApi::class, FlowPreview::class)
+fun <T> TestScope.observeEvent(flow: Flow<T>): Deferred<T> {
+    val event =
+        backgroundScope.async {
+            withTimeout(3000) {
+                flow.first()
+            }
+        }
+    advanceUntilIdle()
+    return event
+}
+
+@OptIn(ExperimentalCoroutinesApi::class, FlowPreview::class)
+fun <T> TestScope.observeMultipleEvent(
+    flow: Flow<T>,
+    result: MutableList<T>,
+) {
+    backgroundScope.launch(UnconfinedTestDispatcher()) {
+        flow
+            .timeout(3.seconds)
+            .collect {
+                result.add(it)
+            }
+    }
+}

--- a/app/src/test/java/com/daedan/festabook/setting/SettingViewModelTest.kt
+++ b/app/src/test/java/com/daedan/festabook/setting/SettingViewModelTest.kt
@@ -2,7 +2,6 @@ package com.daedan.festabook.setting
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import com.daedan.festabook.domain.repository.FestivalNotificationRepository
-import com.daedan.festabook.getOrAwaitValue
 import com.daedan.festabook.presentation.setting.SettingViewModel
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -56,7 +55,7 @@ class SettingViewModelTest {
             advanceUntilIdle()
 
             // then
-            val actual = settingViewModel.permissionCheckEvent.value
+            val actual = settingViewModel.permissionCheckEvent.replayCache.first()
             assertThat(actual).isEqualTo(expected)
         }
 
@@ -72,7 +71,7 @@ class SettingViewModelTest {
             advanceUntilIdle()
 
             // then
-            val result = settingViewModel.isAllowed.getOrAwaitValue()
+            val result = settingViewModel.isAllowed.value
             coVerify { festivalNotificationRepository.setFestivalNotificationIsAllow(false) }
             coVerify { festivalNotificationRepository.deleteFestivalNotification() }
             assertThat(result).isFalse()
@@ -83,7 +82,10 @@ class SettingViewModelTest {
         runTest {
             // given
             coEvery { festivalNotificationRepository.getFestivalNotificationIsAllow() } returns true
-            coEvery { festivalNotificationRepository.deleteFestivalNotification() } returns Result.failure(Throwable())
+            coEvery { festivalNotificationRepository.deleteFestivalNotification() } returns
+                Result.failure(
+                    Throwable(),
+                )
 
             // when
             settingViewModel = SettingViewModel(festivalNotificationRepository)
@@ -91,7 +93,7 @@ class SettingViewModelTest {
             advanceUntilIdle()
 
             // then
-            val result = settingViewModel.isAllowed.getOrAwaitValue()
+            val result = settingViewModel.isAllowed.value
             coVerify { festivalNotificationRepository.setFestivalNotificationIsAllow(true) }
             assertThat(result).isTrue()
         }
@@ -100,14 +102,17 @@ class SettingViewModelTest {
     fun `알림을 허용했을 때 서버에 알림 정보 삭제에 실패하면 이전 상태로 원복한다`() =
         runTest {
             // given
-            coEvery { festivalNotificationRepository.saveFestivalNotification() } returns Result.failure(Throwable())
+            coEvery { festivalNotificationRepository.saveFestivalNotification() } returns
+                Result.failure(
+                    Throwable(),
+                )
 
             // when
             settingViewModel.saveNotificationId()
             advanceUntilIdle()
 
             // then
-            val result = settingViewModel.isAllowed.getOrAwaitValue()
+            val result = settingViewModel.isAllowed.value
             coVerify { festivalNotificationRepository.setFestivalNotificationIsAllow(false) }
             assertThat(result).isFalse()
         }

--- a/app/src/test/java/com/daedan/festabook/setting/SettingViewModelTest.kt
+++ b/app/src/test/java/com/daedan/festabook/setting/SettingViewModelTest.kt
@@ -1,7 +1,7 @@
 package com.daedan.festabook.setting
 
-import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import com.daedan.festabook.domain.repository.FestivalNotificationRepository
+import com.daedan.festabook.observeEvent
 import com.daedan.festabook.presentation.setting.SettingViewModel
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -16,14 +16,11 @@ import kotlinx.coroutines.test.setMain
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.After
 import org.junit.Before
-import org.junit.Rule
 import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertAll
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class SettingViewModelTest {
-    @get:Rule
-    val instantTaskExecutorRule = InstantTaskExecutorRule()
-
     private val testDispatcher = StandardTestDispatcher()
 
     private lateinit var settingViewModel: SettingViewModel
@@ -47,16 +44,17 @@ class SettingViewModelTest {
         runTest {
             // given
             coEvery { festivalNotificationRepository.getFestivalNotificationIsAllow() } returns false
-            val expected = Unit
+            settingViewModel = SettingViewModel(festivalNotificationRepository) // 먼저 생성
+            val event = observeEvent(settingViewModel.permissionCheckEvent)
 
             // when
-            settingViewModel = SettingViewModel(festivalNotificationRepository)
             settingViewModel.notificationAllowClick()
             advanceUntilIdle()
 
             // then
-            val actual = settingViewModel.permissionCheckEvent.replayCache.first()
-            assertThat(actual).isEqualTo(expected)
+            val actual = event.await()
+            advanceUntilIdle()
+            assertThat(actual).isEqualTo(Unit)
         }
 
     @Test
@@ -72,9 +70,11 @@ class SettingViewModelTest {
 
             // then
             val result = settingViewModel.isAllowed.value
-            coVerify { festivalNotificationRepository.setFestivalNotificationIsAllow(false) }
-            coVerify { festivalNotificationRepository.deleteFestivalNotification() }
-            assertThat(result).isFalse()
+            assertAll(
+                { coVerify { festivalNotificationRepository.setFestivalNotificationIsAllow(false) } },
+                { coVerify { festivalNotificationRepository.deleteFestivalNotification() } },
+                { assertThat(result).isFalse() },
+            )
         }
 
     @Test
@@ -94,8 +94,10 @@ class SettingViewModelTest {
 
             // then
             val result = settingViewModel.isAllowed.value
-            coVerify { festivalNotificationRepository.setFestivalNotificationIsAllow(true) }
-            assertThat(result).isTrue()
+            assertAll(
+                { coVerify { festivalNotificationRepository.setFestivalNotificationIsAllow(true) } },
+                { assertThat(result).isTrue() },
+            )
         }
 
     @Test
@@ -113,7 +115,9 @@ class SettingViewModelTest {
 
             // then
             val result = settingViewModel.isAllowed.value
-            coVerify { festivalNotificationRepository.setFestivalNotificationIsAllow(false) }
-            assertThat(result).isFalse()
+            assertAll(
+                { coVerify { festivalNotificationRepository.setFestivalNotificationIsAllow(false) } },
+                { assertThat(result).isFalse() },
+            )
         }
 }


### PR DESCRIPTION
## #️⃣ 이슈 번호

> https://github.com/festabook/android/issues/21

<br>

## 🛠️ 작업 내용

- 설정화면을 Compose로 마이그레이션 하였습니다. 

<br>

## 🙇🏻 중점 리뷰 요청

- 기존 SingleLiveData을 SharedFlow의 replayCache = 1로 설정하여 최대 한 번의 이벤트는 유실되지 않게끔 처리하였습니다. 
(Channel의 경우 다른 곳에서 이벤트를 소비할 경우 동작하지 않습니다)

- ObserveAsEvent는 [해당 PR](https://github.com/festabook/android/pull/24) 에서도 같은 코드를 사용하고 있습니다. PR이 머지가 된다면 해당 코드를 적용하겠습니다. 

- 학생회 페이지에서 푸시 알림 테스트는 통과하였습니다만...혹시 모르니 한 번씩 테스트 부탁드립니다. 

<br>

## 📸 이미지 첨부 (Optional)

<img src="파일주소" width="50%" height="50%"/>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Updated settings screen with university subscription management, app version information, and direct access to policy and contact resources.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->