### PR TITLE
[Refactor] CoilImageLoader를 싱글톤으로 변경

### DIFF
--- a/app/src/main/java/com/daedan/festabook/FestaBookApp.kt
+++ b/app/src/main/java/com/daedan/festabook/FestaBookApp.kt
@@ -2,6 +2,13 @@ package com.daedan.festabook
 
 import android.app.Application
 import androidx.appcompat.app.AppCompatDelegate
+import androidx.core.content.ContextCompat
+import coil3.Image
+import coil3.ImageLoader
+import coil3.PlatformContext
+import coil3.SingletonImageLoader
+import coil3.asImage
+import coil3.request.crossfade
 import com.daedan.festabook.data.datasource.local.DeviceLocalDataSource
 import com.daedan.festabook.data.datasource.local.FcmDataSource
 import com.daedan.festabook.di.FestaBookAppGraph
@@ -17,7 +24,9 @@ import dev.zacsweers.metro.createGraphFactory
 import timber.log.Timber
 import java.util.UUID
 
-class FestaBookApp : Application() {
+class FestaBookApp :
+    Application(),
+    SingletonImageLoader.Factory {
     val festaBookGraph: FestaBookAppGraph by lazy {
         createGraphFactory<FestaBookAppGraph.Factory>().create(this)
     }
@@ -33,6 +42,12 @@ class FestaBookApp : Application() {
 
     @Inject
     private lateinit var fcmDataSource: FcmDataSource
+
+    private val defaultImage: Image? by lazy {
+        ContextCompat
+            .getDrawable(this, R.drawable.img_fallback)
+            ?.asImage()
+    }
 
     override fun onCreate() {
         super.onCreate()
@@ -50,6 +65,14 @@ class FestaBookApp : Application() {
         super.onLowMemory()
         Timber.w("FestabookApp: onLowMemory 호출됨")
     }
+
+    override fun newImageLoader(context: PlatformContext): ImageLoader =
+        ImageLoader
+            .Builder(context)
+            .crossfade(true)
+            .fallback(defaultImage)
+            .error(defaultImage)
+            .build()
 
     private fun sendUnsentReports() {
         Firebase.crashlytics.sendUnsentReports()

--- a/app/src/main/java/com/daedan/festabook/presentation/common/component/CoilImage.kt
+++ b/app/src/main/java/com/daedan/festabook/presentation/common/component/CoilImage.kt
@@ -5,9 +5,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.painter.ColorPainter
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import coil3.compose.AsyncImage
+import coil3.compose.LocalPlatformContext
 import coil3.request.ImageRequest
 import com.daedan.festabook.presentation.common.convertImageUrl
 
@@ -22,7 +22,7 @@ fun CoilImage(
     AsyncImage(
         model =
             ImageRequest
-                .Builder(LocalContext.current)
+                .Builder(LocalPlatformContext.current)
                 .apply(builder)
                 .data(url.convertImageUrl())
                 .build(),

--- a/app/src/main/java/com/daedan/festabook/presentation/common/component/CoilImage.kt
+++ b/app/src/main/java/com/daedan/festabook/presentation/common/component/CoilImage.kt
@@ -6,12 +6,9 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.painter.ColorPainter
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import coil3.compose.AsyncImage
 import coil3.request.ImageRequest
-import coil3.request.crossfade
-import com.daedan.festabook.R
 import com.daedan.festabook.presentation.common.convertImageUrl
 
 @Composable
@@ -28,13 +25,10 @@ fun CoilImage(
                 .Builder(LocalContext.current)
                 .apply(builder)
                 .data(url.convertImageUrl())
-                .crossfade(true)
                 .build(),
         contentDescription = contentDescription,
         contentScale = contentScale,
         placeholder = ColorPainter(Color.LightGray),
-        fallback = painterResource(R.drawable.img_fallback),
-        error = painterResource(R.drawable.img_fallback),
         modifier = modifier,
     )
 }

--- a/app/src/main/java/com/daedan/festabook/presentation/placeMap/placeList/PlaceListFragment.kt
+++ b/app/src/main/java/com/daedan/festabook/presentation/placeMap/placeList/PlaceListFragment.kt
@@ -24,6 +24,7 @@ import com.daedan.festabook.di.appGraph
 import com.daedan.festabook.di.fragment.FragmentKey
 import com.daedan.festabook.presentation.common.BaseFragment
 import com.daedan.festabook.presentation.common.OnMenuItemReClickListener
+import com.daedan.festabook.presentation.common.convertImageUrl
 import com.daedan.festabook.presentation.common.showErrorSnackBar
 import com.daedan.festabook.presentation.placeDetail.PlaceDetailActivity
 import com.daedan.festabook.presentation.placeDetail.model.PlaceDetailUiModel
@@ -202,7 +203,7 @@ class PlaceListFragment(
                             val request =
                                 ImageRequest
                                     .Builder(context)
-                                    .data(place.imageUrl)
+                                    .data(place.imageUrl.convertImageUrl())
                                     .build()
 
                             runCatching {

--- a/app/src/main/java/com/daedan/festabook/presentation/placeMap/placeList/PlaceListFragment.kt
+++ b/app/src/main/java/com/daedan/festabook/presentation/placeMap/placeList/PlaceListFragment.kt
@@ -9,15 +9,13 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
-import androidx.core.content.ContextCompat
 import androidx.core.view.isGone
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.lifecycleScope
-import coil3.ImageLoader
-import coil3.asImage
+import coil3.imageLoader
 import coil3.request.ImageRequest
 import coil3.request.ImageResult
 import com.daedan.festabook.R
@@ -99,10 +97,7 @@ class PlaceListFragment(
                         bottomSheetState = bottomSheetState,
                         isExceedMaxLength = isExceedMaxLength,
                         onPlaceLoadFinish = { places ->
-                            preloadImages(
-                                requireContext(),
-                                places,
-                            )
+                            preloadImages(requireContext(), places)
                         },
                         onPlaceLoad = {
                             viewModel.selectedTimeTagFlow.collect {
@@ -194,14 +189,8 @@ class PlaceListFragment(
         places: List<PlaceUiModel?>,
         maxSize: Int = 20,
     ) {
-        val imageLoader = ImageLoader(context)
+        val imageLoader = context.imageLoader
         val deferredList = mutableListOf<Deferred<ImageResult?>>()
-        val defaultImage =
-            ContextCompat
-                .getDrawable(
-                    requireContext(),
-                    R.drawable.img_fallback,
-                )?.asImage()
 
         lifecycleScope.launch(Dispatchers.IO) {
             places
@@ -214,18 +203,14 @@ class PlaceListFragment(
                                 ImageRequest
                                     .Builder(context)
                                     .data(place.imageUrl)
-                                    .error {
-                                        defaultImage
-                                    }.fallback {
-                                        defaultImage
-                                    }.build()
+                                    .build()
 
                             runCatching {
                                 withTimeout(2000) {
                                     imageLoader.execute(request)
                                 }
                             }.onFailure {
-                                imageLoader.shutdown()
+                                Timber.d("preload 실패")
                             }.getOrNull()
                         }
                     deferredList.add(deferred)


### PR DESCRIPTION
## #️⃣ 이슈 번호

#27 

<br>

## 🛠️ 작업 내용

- `imageLoader.shutdown()`는 `ImageLoader` 인스턴스를 날리는 로직이라고 하네용.
그래서 임시로 `ImageLoader` 객체를 하나 더 생성했을 때 수동으로 없애주기 위해 사용하다고 합니다!
따라서 불필요하다고 생각해서 `shutdown()`이 호출 되지 않게 제거 했습니다.
https://github.com/coil-kt/coil/issues/402

- `ImageLoader`를 `build()`할 때 리스너를 달아서 로그를 찍어보니 캐싱을 잘 하고 있다고 판단했습니다.

```kotlin
.eventListener(
    object : EventListener() {
        override fun onSuccess(
            request: ImageRequest,
            result: SuccessResult,
        ) {
            super.onSuccess(request, result)
            Timber.d("source=${result.dataSource}")
        }
    },
)
```
<img width="1072" height="52" alt="image" src="https://github.com/user-attachments/assets/45bc0b7c-a708-4d50-aae5-b183efac82a7" />

<br>

## 🙇🏻 중점 리뷰 요청

- 개선할 점 있다면 알려주세요.

<br>

## 📸 이미지 첨부 (Optional)


