### PR TITLE
[Feat] SnackbarHost 설정 및 Snackbar Compose 마이그레이션

### DIFF
--- a/app/src/main/java/com/daedan/festabook/presentation/common/component/SnackBar.kt
+++ b/app/src/main/java/com/daedan/festabook/presentation/common/component/SnackBar.kt
@@ -36,10 +36,10 @@ class SnackbarManager(
     private val defaultErrorMessage: String,
 ) {
     fun show(message: String) {
+        hostState.currentSnackbarData?.dismiss()
         scope.launch {
             hostState.showSnackbar(
                 message = message,
-                withDismissAction = true,
                 duration = SnackbarDuration.Short,
                 actionLabel = actionLabel,
             )

--- a/app/src/main/java/com/daedan/festabook/presentation/common/component/SnackBar.kt
+++ b/app/src/main/java/com/daedan/festabook/presentation/common/component/SnackBar.kt
@@ -1,0 +1,79 @@
+package com.daedan.festabook.presentation.common.component
+
+import androidx.compose.material3.Snackbar
+import androidx.compose.material3.SnackbarData
+import androidx.compose.material3.SnackbarDuration
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import com.daedan.festabook.R
+import com.daedan.festabook.data.util.ApiResultException
+import com.daedan.festabook.presentation.theme.FestabookColor
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import kotlin.reflect.KClass
+
+@Composable
+fun FestabookSnackbar(
+    data: SnackbarData,
+    modifier: Modifier = Modifier,
+) {
+    Snackbar(
+        modifier = modifier,
+        snackbarData = data,
+        actionColor = FestabookColor.accentBlue,
+    )
+}
+
+class SnackbarManager(
+    val hostState: SnackbarHostState,
+    val scope: CoroutineScope,
+    private val actionLabel: String,
+    private val errorMessages: Map<KClass<out ApiResultException>, String>,
+    private val defaultErrorMessage: String,
+) {
+    fun show(message: String) {
+        scope.launch {
+            hostState.showSnackbar(
+                message = message,
+                withDismissAction = true,
+                duration = SnackbarDuration.Short,
+                actionLabel = actionLabel,
+            )
+        }
+    }
+
+    fun showError(throwable: Throwable) {
+        val message = errorMessages[throwable::class] ?: throwable.message ?: defaultErrorMessage
+        show(message)
+    }
+}
+
+@Composable
+fun rememberAppSnackbarManager(
+    snackbarHostState: SnackbarHostState,
+    scope: CoroutineScope = rememberCoroutineScope(),
+): SnackbarManager {
+    val clientErrorMessage = stringResource(R.string.error_client_exception)
+    val serverErrorMessage = stringResource(R.string.error_server_exception)
+    val networkErrorMessage = stringResource(R.string.error_network_exception)
+    val unknownErrorMessage = stringResource(R.string.error_unknown_exception)
+    val actionLabel = stringResource(R.string.fail_snackbar_confirm)
+
+    val errorMessages =
+        remember {
+            mapOf(
+                ApiResultException.ClientException::class to clientErrorMessage,
+                ApiResultException.ServerException::class to serverErrorMessage,
+                ApiResultException.NetworkException::class to networkErrorMessage,
+                ApiResultException.UnknownException::class to unknownErrorMessage,
+            )
+        }
+
+    return remember(snackbarHostState, scope) {
+        SnackbarManager(snackbarHostState, scope, actionLabel, errorMessages, unknownErrorMessage)
+    }
+}

--- a/app/src/main/java/com/daedan/festabook/presentation/common/component/SnackBar.kt
+++ b/app/src/main/java/com/daedan/festabook/presentation/common/component/SnackBar.kt
@@ -47,7 +47,7 @@ class SnackbarManager(
     }
 
     fun showError(throwable: Throwable) {
-        val message = errorMessages[throwable::class] ?: throwable.message ?: defaultErrorMessage
+        val message = errorMessages[throwable::class] ?: defaultErrorMessage
         show(message)
     }
 }

--- a/app/src/main/java/com/daedan/festabook/presentation/home/component/HomeScreen.kt
+++ b/app/src/main/java/com/daedan/festabook/presentation/home/component/HomeScreen.kt
@@ -11,7 +11,9 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -37,9 +39,22 @@ fun HomeScreen(
     viewModel: HomeViewModel,
     onNavigateToExplore: () -> Unit,
     modifier: Modifier = Modifier,
+    onShowErrorSnackbar: (Throwable) -> Unit = {}, // TODO Fragment 제거 시 필수 파라미터로 변경
 ) {
     val festivalUiState by viewModel.festivalUiState.collectAsStateWithLifecycle()
     val lineupUiState by viewModel.lineupUiState.collectAsStateWithLifecycle()
+    val currentOnShowErrorSnackbar by rememberUpdatedState(onShowErrorSnackbar)
+    LaunchedEffect(festivalUiState) {
+        when (val state = festivalUiState) {
+            is FestivalUiState.Error -> {
+                currentOnShowErrorSnackbar(state.throwable)
+            }
+
+            else -> {
+                Unit
+            }
+        }
+    }
 
     when (val state = festivalUiState) {
         is FestivalUiState.Loading -> {

--- a/app/src/main/java/com/daedan/festabook/presentation/home/navigation/HomeNavigation.kt
+++ b/app/src/main/java/com/daedan/festabook/presentation/home/navigation/HomeNavigation.kt
@@ -13,6 +13,7 @@ import com.daedan.festabook.presentation.main.component.FirstVisitDialog
 fun NavGraphBuilder.homeNavGraph(
     viewModel: HomeViewModel,
     mainViewModel: MainViewModel,
+    onShowErrorSnackbar: (Throwable) -> Unit,
     onSubscriptionConfirm: () -> Unit,
     onNavigateToExplore: () -> Unit,
 ) {
@@ -26,6 +27,7 @@ fun NavGraphBuilder.homeNavGraph(
         }
         HomeScreen(
             viewModel = viewModel,
+            onShowErrorSnackbar = onShowErrorSnackbar,
             onNavigateToExplore = onNavigateToExplore,
         )
     }

--- a/app/src/main/java/com/daedan/festabook/presentation/main/component/MainScreen.kt
+++ b/app/src/main/java/com/daedan/festabook/presentation/main/component/MainScreen.kt
@@ -135,6 +135,7 @@ fun MainScreen(
             placeMapViewModel = placeMapViewModel,
             locationSource = locationSource,
             logger = logger,
+            onShowErrorSnackBar = snackbarManager::showError,
             onStartPlaceDetail = {
                 navigator.navigate(
                     FestabookRoute.PlaceDetail(

--- a/app/src/main/java/com/daedan/festabook/presentation/main/component/MainScreen.kt
+++ b/app/src/main/java/com/daedan/festabook/presentation/main/component/MainScreen.kt
@@ -78,9 +78,6 @@ fun MainScreen(
     ObserveAsEvents(flow = homeViewModel.navigateToScheduleEvent) {
         navigator.navigateToMainTab(FestabookMainTab.SCHEDULE)
     }
-    ObserveAsEvents(flow = settingViewModel.success) {
-        snackbarManager.show(noticeEnabledMessage)
-    }
 
     BackHandler {
         mainViewModel.onBackPressed()

--- a/app/src/main/java/com/daedan/festabook/presentation/main/component/MainScreen.kt
+++ b/app/src/main/java/com/daedan/festabook/presentation/main/component/MainScreen.kt
@@ -3,16 +3,24 @@ package com.daedan.festabook.presentation.main.component
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.res.stringResource
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.compose.NavHost
+import com.daedan.festabook.R
 import com.daedan.festabook.logging.DefaultFirebaseLogger
 import com.daedan.festabook.presentation.NotificationPermissionManager
 import com.daedan.festabook.presentation.common.ObserveAsEvents
+import com.daedan.festabook.presentation.common.component.FestabookSnackbar
+import com.daedan.festabook.presentation.common.component.SnackbarManager
+import com.daedan.festabook.presentation.common.component.rememberAppSnackbarManager
 import com.daedan.festabook.presentation.home.HomeViewModel
 import com.daedan.festabook.presentation.home.navigation.homeNavGraph
 import com.daedan.festabook.presentation.main.FestabookMainTab
@@ -52,6 +60,10 @@ fun MainScreen(
     settingViewModel: SettingViewModel = viewModel(),
 ) {
     val navigator = rememberFestabookNavigator()
+    val snackbarHostState = remember { SnackbarHostState() }
+    val snackbarManager = rememberAppSnackbarManager(snackbarHostState)
+    val backPressExitMessage = stringResource(R.string.back_press_exit_message)
+    val noticeEnabledMessage = stringResource(R.string.setting_notice_enabled)
 
     ObserveAsEvents(flow = mainViewModel.navigateNewsEvent) {
         navigator.navigateToMainTab(FestabookMainTab.NEWS)
@@ -60,23 +72,25 @@ fun MainScreen(
         if (isDoublePress) {
             onAppFinish()
         } else {
-            // TODO: SnackBarHost로 변경
-//            showToast(getString(R.string.back_press_exit_message))
+            snackbarManager.show(backPressExitMessage)
         }
     }
     ObserveAsEvents(flow = homeViewModel.navigateToScheduleEvent) {
         navigator.navigateToMainTab(FestabookMainTab.SCHEDULE)
     }
     ObserveAsEvents(flow = settingViewModel.success) {
-        // TODO: SnackBarHost로 변경
-//        showSnackBar(getString(R.string.setting_notice_enabled))
+        snackbarManager.show(noticeEnabledMessage)
     }
 
     BackHandler {
         mainViewModel.onBackPressed()
     }
     Scaffold(
-        // TODO: 스낵바 구현 및 하위 프래그먼트에 해당 SnackBar 적용
+        snackbarHost = {
+            SnackbarHost(hostState = snackbarHostState) { data ->
+                FestabookSnackbar(data)
+            }
+        },
         bottomBar = {
             if (navigator.shouldShowBottomBar) {
                 FestabookBottomNavigationBar(
@@ -144,6 +158,7 @@ fun MainScreen(
             notificationPermissionManager = notificationPermissionManager,
             onNavigateToExplore = onNavigateToExplore,
             onSubscriptionConfirm = onSubscriptionConfirm,
+            snackbarManager = snackbarManager,
         )
     }
 }
@@ -160,6 +175,7 @@ private fun FestabookNavHost(
     notificationPermissionManager: NotificationPermissionManager,
     onNavigateToExplore: () -> Unit,
     onSubscriptionConfirm: () -> Unit,
+    snackbarManager: SnackbarManager,
     modifier: Modifier = Modifier,
 ) {
     NavHost(
@@ -187,8 +203,8 @@ private fun FestabookNavHost(
             homeViewModel = homeViewModel,
             settingViewModel = settingViewModel,
             notificationPermissionManager = notificationPermissionManager,
-            onShowSnackBar = { },
-            onShowErrorSnackBar = { },
+            onShowSnackBar = snackbarManager::show,
+            onShowErrorSnackBar = snackbarManager::showError,
         )
     }
 }

--- a/app/src/main/java/com/daedan/festabook/presentation/main/component/MainScreen.kt
+++ b/app/src/main/java/com/daedan/festabook/presentation/main/component/MainScreen.kt
@@ -195,6 +195,7 @@ private fun FestabookNavHost(
         placeMapNavGraph(
             placeDetailViewModelFactory = placeDetailViewModelFactory,
             onBackToPreviousClick = { navigator.popBackStack() },
+            onShowErrorSnackbar = snackbarManager::showError,
         )
         newsNavGraph(
             viewModel = newsViewModel,

--- a/app/src/main/java/com/daedan/festabook/presentation/main/component/MainScreen.kt
+++ b/app/src/main/java/com/daedan/festabook/presentation/main/component/MainScreen.kt
@@ -188,9 +188,11 @@ private fun FestabookNavHost(
             mainViewModel = mainViewModel,
             onNavigateToExplore = onNavigateToExplore,
             onSubscriptionConfirm = onSubscriptionConfirm,
+            onShowErrorSnackbar = snackbarManager::showError,
         )
         scheduleNavGraph(
             viewModel = scheduleViewModel,
+            onShowErrorSnackbar = snackbarManager::showError,
         )
         placeMapNavGraph(
             placeDetailViewModelFactory = placeDetailViewModelFactory,
@@ -199,6 +201,7 @@ private fun FestabookNavHost(
         )
         newsNavGraph(
             viewModel = newsViewModel,
+            onShowErrorSnackbar = snackbarManager::showError,
         )
         settingNavGraph(
             homeViewModel = homeViewModel,

--- a/app/src/main/java/com/daedan/festabook/presentation/news/component/NewsScreen.kt
+++ b/app/src/main/java/com/daedan/festabook/presentation/news/component/NewsScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -16,6 +17,7 @@ import com.daedan.festabook.R
 import com.daedan.festabook.presentation.common.component.FestabookTopAppBar
 import com.daedan.festabook.presentation.news.NewsTab
 import com.daedan.festabook.presentation.news.NewsViewModel
+import com.daedan.festabook.presentation.news.faq.FAQUiState
 import com.daedan.festabook.presentation.news.lost.LostUiState
 import com.daedan.festabook.presentation.news.notice.NoticeUiState
 
@@ -23,6 +25,7 @@ import com.daedan.festabook.presentation.news.notice.NoticeUiState
 fun NewsScreen(
     newsViewModel: NewsViewModel,
     modifier: Modifier = Modifier,
+    onShowErrorSnackbar: (Throwable) -> Unit = {}, // TODO Fragment 제거 시 필수 파라미터로 변경
 ) {
     val pageState = rememberPagerState { NewsTab.entries.size }
     val scope = rememberCoroutineScope()
@@ -30,15 +33,50 @@ fun NewsScreen(
     val noticeUiState by newsViewModel.noticeUiState.collectAsStateWithLifecycle()
     val lostUiState by newsViewModel.lostUiState.collectAsStateWithLifecycle()
     val faqUiState by newsViewModel.faqUiState.collectAsStateWithLifecycle()
+    val currentOnShowErrorSnackbar by rememberUpdatedState(onShowErrorSnackbar)
 
     val isNoticeRefreshing = noticeUiState is NoticeUiState.Refreshing
     val isLostItemRefreshing = lostUiState is LostUiState.Refreshing
 
     LaunchedEffect(noticeUiState) {
-        if (noticeUiState is NoticeUiState.Success) {
-            pageState.animateScrollToPage(NewsTab.NOTICE.ordinal)
+        when (val uiState = noticeUiState) {
+            is NoticeUiState.Success -> {
+                pageState.animateScrollToPage(NewsTab.NOTICE.ordinal)
+            }
+
+            is NoticeUiState.Error -> {
+                currentOnShowErrorSnackbar(uiState.throwable)
+            }
+
+            else -> {
+                Unit
+            }
         }
     }
+    LaunchedEffect(lostUiState) {
+        when (val uiState = lostUiState) {
+            is LostUiState.Error -> {
+                currentOnShowErrorSnackbar(uiState.throwable)
+            }
+
+            else -> {
+                Unit
+            }
+        }
+    }
+
+    LaunchedEffect(faqUiState) {
+        when (val uiState = faqUiState) {
+            is FAQUiState.Error -> {
+                currentOnShowErrorSnackbar(uiState.throwable)
+            }
+
+            else -> {
+                Unit
+            }
+        }
+    }
+
     Scaffold(
         topBar = { FestabookTopAppBar(title = stringResource(R.string.news_title)) },
         modifier = modifier,

--- a/app/src/main/java/com/daedan/festabook/presentation/news/navigation/NewsNavigation.kt
+++ b/app/src/main/java/com/daedan/festabook/presentation/news/navigation/NewsNavigation.kt
@@ -6,10 +6,14 @@ import com.daedan.festabook.presentation.main.MainTabRoute
 import com.daedan.festabook.presentation.news.NewsViewModel
 import com.daedan.festabook.presentation.news.component.NewsScreen
 
-fun NavGraphBuilder.newsNavGraph(viewModel: NewsViewModel) {
+fun NavGraphBuilder.newsNavGraph(
+    viewModel: NewsViewModel,
+    onShowErrorSnackbar: (Throwable) -> Unit,
+) {
     composable<MainTabRoute.News> {
         NewsScreen(
             newsViewModel = viewModel,
+            onShowErrorSnackbar = onShowErrorSnackbar,
         )
     }
 }

--- a/app/src/main/java/com/daedan/festabook/presentation/placeDetail/component/PlaceDetailScreen.kt
+++ b/app/src/main/java/com/daedan/festabook/presentation/placeDetail/component/PlaceDetailScreen.kt
@@ -70,6 +70,7 @@ import com.daedan.festabook.presentation.theme.festabookSpacing
 fun PlaceDetailRoute(
     viewModel: PlaceDetailViewModel,
     onBackToPreviousClick: () -> Unit,
+    onShowErrorSnackbar: (Throwable) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val placeDetailUiState by viewModel.placeDetail.collectAsStateWithLifecycle()
@@ -77,19 +78,35 @@ fun PlaceDetailRoute(
         modifier = modifier,
         uiState = placeDetailUiState,
         onBackToPreviousClick = onBackToPreviousClick,
+        onShowErrorSnackbar = onShowErrorSnackbar,
     )
 }
 
 @Composable
 fun PlaceDetailScreen(
     uiState: PlaceDetailUiState,
+    onShowErrorSnackbar: (Throwable) -> Unit,
     onBackToPreviousClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val scrollState = rememberScrollState()
+    val currentOnShowErrorSnackbar by rememberUpdatedState(onShowErrorSnackbar)
     var isDialogOpen by remember { mutableStateOf(false) }
+
     BackHandler(enabled = !isDialogOpen) {
         onBackToPreviousClick()
+    }
+
+    LaunchedEffect(uiState) {
+        when (uiState) {
+            is PlaceDetailUiState.Error -> {
+                currentOnShowErrorSnackbar(uiState.throwable)
+            }
+
+            else -> {
+                Unit
+            }
+        }
     }
 
     when (uiState) {
@@ -410,6 +427,7 @@ private fun PlaceDetailScreenPreview() {
     FestabookTheme {
         PlaceDetailScreen(
             onBackToPreviousClick = {},
+            onShowErrorSnackbar = {},
             uiState =
                 PlaceDetailUiState.Success(
                     placeDetail =

--- a/app/src/main/java/com/daedan/festabook/presentation/placeDetail/component/PlaceDetailScreen.kt
+++ b/app/src/main/java/com/daedan/festabook/presentation/placeDetail/component/PlaceDetailScreen.kt
@@ -85,9 +85,9 @@ fun PlaceDetailRoute(
 @Composable
 fun PlaceDetailScreen(
     uiState: PlaceDetailUiState,
-    onShowErrorSnackbar: (Throwable) -> Unit,
     onBackToPreviousClick: () -> Unit,
     modifier: Modifier = Modifier,
+    onShowErrorSnackbar: (Throwable) -> Unit = {}, // TODO Fragment 제거 시 필수 파라미터로 변경
 ) {
     val scrollState = rememberScrollState()
     val currentOnShowErrorSnackbar by rememberUpdatedState(onShowErrorSnackbar)

--- a/app/src/main/java/com/daedan/festabook/presentation/placeMap/component/PlaceMapScreen.kt
+++ b/app/src/main/java/com/daedan/festabook/presentation/placeMap/component/PlaceMapScreen.kt
@@ -54,6 +54,7 @@ import timber.log.Timber
 fun PlaceMapRoute(
     placeMapViewModel: PlaceMapViewModel,
     onStartPlaceDetail: (PlaceMapSideEffect.StartPlaceDetail) -> Unit,
+    onShowErrorSnackBar: (Throwable) -> Unit,
     locationSource: FusedLocationSource,
     logger: DefaultFirebaseLogger,
     modifier: Modifier = Modifier,
@@ -92,7 +93,7 @@ fun PlaceMapRoute(
                         places = it.places,
                     )
                 },
-                onShowErrorSnackBar = { },
+                onShowErrorSnackBar = { onShowErrorSnackBar(it.error.throwable) },
             )
         }
 

--- a/app/src/main/java/com/daedan/festabook/presentation/placeMap/navigation/PlaceMapNavigation.kt
+++ b/app/src/main/java/com/daedan/festabook/presentation/placeMap/navigation/PlaceMapNavigation.kt
@@ -26,6 +26,7 @@ import kotlin.reflect.typeOf
 fun NavGraphBuilder.placeMapNavGraph(
     onBackToPreviousClick: () -> Unit,
     placeDetailViewModelFactory: PlaceDetailViewModel.Factory,
+    onShowErrorSnackbar: (Throwable) -> Unit,
 ) {
     composable<MainTabRoute.PlaceMap> {
     }
@@ -56,13 +57,12 @@ fun NavGraphBuilder.placeMapNavGraph(
         PlaceDetailRoute(
             modifier =
                 Modifier.graphicsLayer(
-                    // compositingStrategy를 사용해 자식들을 하나의 레이어로 강제 통합
                     compositingStrategy = CompositingStrategy.Offscreen,
-                    // 하드웨어 가속을 통해 애니메이션 도중 레이어가 쪼개지는 것을 방지
                     clip = true,
                 ),
             viewModel = viewModel,
             onBackToPreviousClick = onBackToPreviousClick,
+            onShowErrorSnackbar = onShowErrorSnackbar,
         )
     }
 }

--- a/app/src/main/java/com/daedan/festabook/presentation/schedule/component/ScheduleScreen.kt
+++ b/app/src/main/java/com/daedan/festabook/presentation/schedule/component/ScheduleScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -29,14 +30,28 @@ import timber.log.Timber
 fun ScheduleScreen(
     scheduleViewModel: ScheduleViewModel,
     modifier: Modifier = Modifier,
+    onShowErrorSnackbar: (Throwable) -> Unit = {}, // TODO Fragment 제거 시 필수 파라미터로 변경
 ) {
     val scheduleUiState by scheduleViewModel.scheduleUiState.collectAsStateWithLifecycle()
+    val currentOnShowErrorSnackbar by rememberUpdatedState(onShowErrorSnackbar)
     val currentState =
         when (scheduleUiState) {
             is ScheduleUiState.Refreshing -> (scheduleUiState as ScheduleUiState.Refreshing).lastSuccessState
             is ScheduleUiState.Success -> scheduleUiState
             else -> scheduleUiState
         }
+
+    LaunchedEffect(currentState) {
+        when (currentState) {
+            is ScheduleUiState.Error -> {
+                currentOnShowErrorSnackbar(currentState.throwable)
+            }
+
+            else -> {
+                Unit
+            }
+        }
+    }
 
     Scaffold(
         topBar = { FestabookTopAppBar(title = stringResource(R.string.schedule_title)) },

--- a/app/src/main/java/com/daedan/festabook/presentation/schedule/navigation/ScheduleNavigation.kt
+++ b/app/src/main/java/com/daedan/festabook/presentation/schedule/navigation/ScheduleNavigation.kt
@@ -6,10 +6,14 @@ import com.daedan.festabook.presentation.main.MainTabRoute
 import com.daedan.festabook.presentation.schedule.ScheduleViewModel
 import com.daedan.festabook.presentation.schedule.component.ScheduleScreen
 
-fun NavGraphBuilder.scheduleNavGraph(viewModel: ScheduleViewModel) {
+fun NavGraphBuilder.scheduleNavGraph(
+    viewModel: ScheduleViewModel,
+    onShowErrorSnackbar: (Throwable) -> Unit,
+) {
     composable<MainTabRoute.Schedule> {
         ScheduleScreen(
             scheduleViewModel = viewModel,
+            onShowErrorSnackbar = onShowErrorSnackbar,
         )
     }
 }


### PR DESCRIPTION
## #️⃣ 이슈 번호

> https://github.com/festabook/android/issues/34

<br>

## 🛠️ 작업 내용

- Scaffold에 SnackbarHost 추가 및 Compose Snackbar로 마이그레이션 하였습니다. 
- MainActivity에 아직 레거시 스낵바 호출 코드가 남아있습니다. 이 부분은 [해당 이슈](https://github.com/festabook/android/issues/45)
를 진행함과 동시에 마이그레이션 하는 것이 좋을 것 같습니다. 

<br>

## 🙇🏻 중점 리뷰 요청

- 각 메인 탭의 최상단 UiState가 Error 상태일 때만 스낵바를 띄웁니다. 
각자 작업하신 화면에서 스낵바 호출이 누락된 부분이 있다면 코멘트 부탁드립니다 !

<br>

## 📸 이미지 첨부 (Optional)

<img src="파일주소" width="50%" height="50%"/>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 에러 발생 시 사용자에게 스낵바 알림으로 메시지 표시
  * 앱 전체 화면에서 일관된 에러 처리 및 사용자 피드백 개선
  * 뒤로가기 동작 및 다양한 상황에서 알림 메시지 제공

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->