### PR TITLE
[Feat] Splash, Explore 액티비티 Main과 연동

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -23,12 +23,7 @@
         <activity
             android:name=".presentation.splash.SplashActivity"
             android:exported="true"
-            android:theme="@style/Theme.Festabook.Splash">
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
-                <category android:name="android.intent.category.LAUNCHER" />
-            </intent-filter>
-        </activity>
+            android:theme="@style/Theme.Festabook.Splash" />
 
         <activity
             android:name=".presentation.explore.ExploreActivity"
@@ -43,19 +38,22 @@
             android:name=".presentation.main.MainActivity"
             android:exported="true"
             android:screenOrientation="portrait"
-            tools:ignore="DiscouragedApi, LockedOrientationActivity" />
+            tools:ignore="DiscouragedApi, LockedOrientationActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
         <activity
             android:name=".presentation.placeDetail.PlaceDetailActivity"
             android:exported="false"
             android:screenOrientation="portrait"
-            tools:ignore="DiscouragedApi, LockedOrientationActivity">
-        </activity>
+            tools:ignore="DiscouragedApi, LockedOrientationActivity" />
         <activity
             android:name=".presentation.error.ErrorActivity"
             android:exported="false"
             android:screenOrientation="portrait"
-            tools:ignore="DiscouragedApi, LockedOrientationActivity">
-        </activity>
+            tools:ignore="DiscouragedApi, LockedOrientationActivity" />
 
         <service
             android:name=".service.MyFirebaseMessagingService"

--- a/app/src/main/java/com/daedan/festabook/presentation/FestabookScreen.kt
+++ b/app/src/main/java/com/daedan/festabook/presentation/FestabookScreen.kt
@@ -1,0 +1,61 @@
+package com.daedan.festabook.presentation
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.compose.NavHost
+import com.daedan.festabook.logging.DefaultFirebaseLogger
+import com.daedan.festabook.presentation.explore.ExploreViewModel
+import com.daedan.festabook.presentation.explore.navigation.exploreNavGraph
+import com.daedan.festabook.presentation.main.FestabookRoute
+import com.daedan.festabook.presentation.main.navigation.mainNavGraph
+import com.daedan.festabook.presentation.main.rememberFestabookNavigator
+import com.daedan.festabook.presentation.placeDetail.PlaceDetailViewModel
+import com.daedan.festabook.presentation.splash.AppVersionManager
+import com.daedan.festabook.presentation.splash.SplashViewModel
+import com.daedan.festabook.presentation.splash.navigation.splashNavGraph
+import com.naver.maps.map.util.FusedLocationSource
+
+@Composable
+fun FestabookScreen(
+    appVersionManager: AppVersionManager,
+    notificationPermissionManager: NotificationPermissionManager,
+    placeDetailViewModelFactory: PlaceDetailViewModel.Factory,
+    defaultViewModelFactory: ViewModelProvider.Factory,
+    locationSource: FusedLocationSource,
+    logger: DefaultFirebaseLogger,
+    modifier: Modifier = Modifier,
+    splashViewModel: SplashViewModel = viewModel(),
+    exploreViewModel: ExploreViewModel = viewModel(),
+) {
+    val festabookNavigator = rememberFestabookNavigator()
+
+    NavHost(
+        modifier = modifier,
+        startDestination = festabookNavigator.startRoute,
+        navController = festabookNavigator.navController,
+    ) {
+        splashNavGraph(
+            viewModel = splashViewModel,
+            appVersionManager = appVersionManager,
+            onNavigateToExplore = { festabookNavigator.navigate(FestabookRoute.Explore) },
+            onNavigateToMain = { festabookNavigator.navigate(FestabookRoute.Main) },
+            onFinishApp = { festabookNavigator.popBackStack() },
+        )
+        exploreNavGraph(
+            viewModel = exploreViewModel,
+            onBackClick = { festabookNavigator.popBackStack() },
+            onNavigateToMain = { festabookNavigator.navigate(FestabookRoute.Main) },
+        )
+        mainNavGraph(
+            placeDetailViewModelFactory = placeDetailViewModelFactory,
+            defaultViewModelFactory = defaultViewModelFactory,
+            notificationPermissionManager = notificationPermissionManager,
+            locationSource = locationSource,
+            logger = logger,
+            onSubscriptionConfirm = { festabookNavigator.navigate(FestabookRoute.Main) },
+            festabookNavigator = festabookNavigator,
+        )
+    }
+}

--- a/app/src/main/java/com/daedan/festabook/presentation/FestabookScreen.kt
+++ b/app/src/main/java/com/daedan/festabook/presentation/FestabookScreen.kt
@@ -12,6 +12,7 @@ import com.daedan.festabook.presentation.main.FestabookRoute
 import com.daedan.festabook.presentation.main.navigation.mainNavGraph
 import com.daedan.festabook.presentation.main.rememberFestabookNavigator
 import com.daedan.festabook.presentation.placeDetail.PlaceDetailViewModel
+import com.daedan.festabook.presentation.setting.SettingViewModel
 import com.daedan.festabook.presentation.splash.AppVersionManager
 import com.daedan.festabook.presentation.splash.SplashViewModel
 import com.daedan.festabook.presentation.splash.navigation.splashNavGraph
@@ -26,6 +27,7 @@ fun FestabookScreen(
     locationSource: FusedLocationSource,
     logger: DefaultFirebaseLogger,
     modifier: Modifier = Modifier,
+    settingViewModel: SettingViewModel = viewModel(),
     splashViewModel: SplashViewModel = viewModel(),
     exploreViewModel: ExploreViewModel = viewModel(),
 ) {
@@ -56,6 +58,7 @@ fun FestabookScreen(
             logger = logger,
             onSubscriptionConfirm = { festabookNavigator.navigate(FestabookRoute.Main) },
             festabookNavigator = festabookNavigator,
+            settingViewModel = settingViewModel,
         )
     }
 }

--- a/app/src/main/java/com/daedan/festabook/presentation/FestabookScreen.kt
+++ b/app/src/main/java/com/daedan/festabook/presentation/FestabookScreen.kt
@@ -9,8 +9,10 @@ import com.daedan.festabook.logging.DefaultFirebaseLogger
 import com.daedan.festabook.presentation.explore.ExploreViewModel
 import com.daedan.festabook.presentation.explore.navigation.exploreNavGraph
 import com.daedan.festabook.presentation.main.FestabookRoute
+import com.daedan.festabook.presentation.main.MainViewModel
 import com.daedan.festabook.presentation.main.navigation.mainNavGraph
 import com.daedan.festabook.presentation.main.rememberFestabookNavigator
+import com.daedan.festabook.presentation.news.NewsViewModel
 import com.daedan.festabook.presentation.placeDetail.PlaceDetailViewModel
 import com.daedan.festabook.presentation.setting.SettingViewModel
 import com.daedan.festabook.presentation.splash.AppVersionManager
@@ -27,6 +29,8 @@ fun FestabookScreen(
     locationSource: FusedLocationSource,
     logger: DefaultFirebaseLogger,
     modifier: Modifier = Modifier,
+    newsViewModel: NewsViewModel = viewModel(),
+    mainViewModel: MainViewModel = viewModel(),
     settingViewModel: SettingViewModel = viewModel(),
     splashViewModel: SplashViewModel = viewModel(),
     exploreViewModel: ExploreViewModel = viewModel(),
@@ -59,6 +63,8 @@ fun FestabookScreen(
             onSubscriptionConfirm = { festabookNavigator.navigate(FestabookRoute.Main) },
             festabookNavigator = festabookNavigator,
             settingViewModel = settingViewModel,
+            mainViewModel = mainViewModel,
+            newsViewModel = newsViewModel,
         )
     }
 }

--- a/app/src/main/java/com/daedan/festabook/presentation/explore/navigation/ExploreNavigation.kt
+++ b/app/src/main/java/com/daedan/festabook/presentation/explore/navigation/ExploreNavigation.kt
@@ -1,0 +1,21 @@
+package com.daedan.festabook.presentation.explore.navigation
+
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.compose.composable
+import com.daedan.festabook.presentation.explore.ExploreViewModel
+import com.daedan.festabook.presentation.explore.component.ExploreScreen
+import com.daedan.festabook.presentation.main.FestabookRoute
+
+fun NavGraphBuilder.exploreNavGraph(
+    viewModel: ExploreViewModel,
+    onBackClick: () -> Unit,
+    onNavigateToMain: () -> Unit,
+) {
+    composable<FestabookRoute.Explore> {
+        ExploreScreen(
+            viewModel = viewModel,
+            onBackClick = onBackClick,
+            onNavigateToMain = { onNavigateToMain() },
+        )
+    }
+}

--- a/app/src/main/java/com/daedan/festabook/presentation/main/FestabookNavigator.kt
+++ b/app/src/main/java/com/daedan/festabook/presentation/main/FestabookNavigator.kt
@@ -12,6 +12,7 @@ import androidx.navigation.navOptions
 
 class FestabookNavigator(
     val navController: NavHostController,
+    val startRoute: FestabookRoute = FestabookRoute.Splash,
 ) {
     private val currentDestination
         @Composable
@@ -35,8 +36,6 @@ class FestabookNavigator(
             FestabookMainTab.find {
                 currentDestination?.hasRoute(it::class) ?: false
             } != null
-
-    val startRoute = FestabookRoute.Splash
 
     fun navigateToMainTab(tab: FestabookMainTab) {
         navController.navigate(
@@ -74,9 +73,9 @@ class FestabookNavigator(
 }
 
 @Composable
-fun rememberFestabookNavigator(): FestabookNavigator {
+fun rememberFestabookNavigator(startRoute: FestabookRoute = FestabookRoute.Splash): FestabookNavigator {
     val navController = rememberNavController()
     return remember {
-        FestabookNavigator(navController = navController)
+        FestabookNavigator(navController = navController, startRoute = startRoute)
     }
 }

--- a/app/src/main/java/com/daedan/festabook/presentation/main/FestabookNavigator.kt
+++ b/app/src/main/java/com/daedan/festabook/presentation/main/FestabookNavigator.kt
@@ -36,7 +36,7 @@ class FestabookNavigator(
                 currentDestination?.hasRoute(it::class) ?: false
             } != null
 
-    val startRoute = MainTabRoute.Home // TODO: Splash와 Explore 연동 시 변경
+    val startRoute = FestabookRoute.Splash
 
     fun navigateToMainTab(tab: FestabookMainTab) {
         navController.navigate(

--- a/app/src/main/java/com/daedan/festabook/presentation/main/FestabookRoute.kt
+++ b/app/src/main/java/com/daedan/festabook/presentation/main/FestabookRoute.kt
@@ -17,6 +17,9 @@ sealed interface FestabookRoute {
 
     @Serializable
     data object Explore : FestabookRoute
+
+    @Serializable
+    data object Main : FestabookRoute
 }
 
 @Serializable

--- a/app/src/main/java/com/daedan/festabook/presentation/main/MainActivity.kt
+++ b/app/src/main/java/com/daedan/festabook/presentation/main/MainActivity.kt
@@ -14,11 +14,11 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.lifecycle.ViewModelProvider
 import com.daedan.festabook.R
 import com.daedan.festabook.di.appGraph
+import com.daedan.festabook.presentation.FestabookScreen
 import com.daedan.festabook.presentation.NotificationPermissionManager
 import com.daedan.festabook.presentation.NotificationPermissionRequester
 import com.daedan.festabook.presentation.common.isGranted
 import com.daedan.festabook.presentation.common.showNotificationDeniedSnackbar
-import com.daedan.festabook.presentation.main.component.MainScreen
 import com.daedan.festabook.presentation.news.NewsViewModel
 import com.daedan.festabook.presentation.placeDetail.PlaceDetailViewModel
 import com.daedan.festabook.presentation.setting.SettingViewModel
@@ -105,16 +105,13 @@ class MainActivity :
             }
 
             FestabookTheme {
-                MainScreen(
+                FestabookScreen(
                     notificationPermissionManager = notificationPermissionManager,
                     logger = appGraph.defaultFirebaseLogger,
                     locationSource = locationSource,
                     placeDetailViewModelFactory = viewModelFactory,
-                    onAppFinish = { finish() },
-                    onSubscriptionConfirm = {
-                        notificationPermissionManager.requestNotificationPermission(this)
-                    },
                     appVersionManager = appVersionManager,
+                    defaultViewModelFactory = defaultViewModelProviderFactory,
                 )
             }
         }

--- a/app/src/main/java/com/daedan/festabook/presentation/main/MainActivity.kt
+++ b/app/src/main/java/com/daedan/festabook/presentation/main/MainActivity.kt
@@ -118,7 +118,6 @@ class MainActivity :
         mainViewModel.registerDeviceAndFcmToken()
     }
 
-    // TODO SnackBarHost로 변경
     override fun onRequestPermissionsResult(
         requestCode: Int,
         permissions: Array<out String>,

--- a/app/src/main/java/com/daedan/festabook/presentation/main/MainActivity.kt
+++ b/app/src/main/java/com/daedan/festabook/presentation/main/MainActivity.kt
@@ -18,11 +18,12 @@ import com.daedan.festabook.presentation.NotificationPermissionManager
 import com.daedan.festabook.presentation.NotificationPermissionRequester
 import com.daedan.festabook.presentation.common.isGranted
 import com.daedan.festabook.presentation.common.showNotificationDeniedSnackbar
-import com.daedan.festabook.presentation.explore.ExploreActivity
 import com.daedan.festabook.presentation.main.component.MainScreen
 import com.daedan.festabook.presentation.news.NewsViewModel
 import com.daedan.festabook.presentation.placeDetail.PlaceDetailViewModel
 import com.daedan.festabook.presentation.setting.SettingViewModel
+import com.daedan.festabook.presentation.splash.AppVersionManager
+import com.daedan.festabook.presentation.splash.SplashViewModel
 import com.daedan.festabook.presentation.theme.FestabookTheme
 import com.naver.maps.map.util.FusedLocationSource
 import dev.zacsweers.metro.Inject
@@ -40,9 +41,14 @@ class MainActivity :
     @Inject
     private lateinit var notificationPermissionManagerFactory: NotificationPermissionManager.Factory
 
+    @Inject
+    private lateinit var appVersionManagerFactory: AppVersionManager.Factory
+
     private val mainViewModel: MainViewModel by viewModels()
     private val newsViewModel: NewsViewModel by viewModels()
     private val settingViewModel: SettingViewModel by viewModels()
+
+    private val splashViewModel: SplashViewModel by viewModels()
 
     private val notificationPermissionManager by lazy {
         notificationPermissionManagerFactory.create(
@@ -52,9 +58,22 @@ class MainActivity :
         )
     }
 
+    private val updateResultLauncher =
+        registerForActivityResult(
+            ActivityResultContracts.StartIntentSenderForResult(),
+        ) { result ->
+            if (result.resultCode == RESULT_OK) {
+                splashViewModel.handleVersionCheckResult(Result.success(false))
+            } else {
+                splashViewModel.handleVersionCheckResult(Result.failure(Exception("Update failed")))
+            }
+        }
+
     private val locationSource by lazy {
         FusedLocationSource(this, LOCATION_PERMISSION_REQUEST_CODE)
     }
+
+    private val appVersionManager by lazy { appVersionManagerFactory.create(updateResultLauncher) }
 
     override val permissionLauncher: ActivityResultLauncher<String> =
         registerForActivityResult(
@@ -95,9 +114,7 @@ class MainActivity :
                     onSubscriptionConfirm = {
                         notificationPermissionManager.requestNotificationPermission(this)
                     },
-                    onNavigateToExplore = {
-                        startActivity(ExploreActivity.newIntent(this))
-                    },
+                    appVersionManager = appVersionManager,
                 )
             }
         }

--- a/app/src/main/java/com/daedan/festabook/presentation/main/component/MainScreen.kt
+++ b/app/src/main/java/com/daedan/festabook/presentation/main/component/MainScreen.kt
@@ -12,7 +12,6 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.res.stringResource
-import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.compose.NavHost
 import com.daedan.festabook.R
 import com.daedan.festabook.logging.DefaultFirebaseLogger
@@ -21,8 +20,6 @@ import com.daedan.festabook.presentation.common.ObserveAsEvents
 import com.daedan.festabook.presentation.common.component.FestabookSnackbar
 import com.daedan.festabook.presentation.common.component.SnackbarManager
 import com.daedan.festabook.presentation.common.component.rememberAppSnackbarManager
-import com.daedan.festabook.presentation.explore.ExploreViewModel
-import com.daedan.festabook.presentation.explore.navigation.exploreNavGraph
 import com.daedan.festabook.presentation.home.HomeViewModel
 import com.daedan.festabook.presentation.home.navigation.homeNavGraph
 import com.daedan.festabook.presentation.main.FestabookMainTab
@@ -42,9 +39,6 @@ import com.daedan.festabook.presentation.schedule.ScheduleViewModel
 import com.daedan.festabook.presentation.schedule.navigation.scheduleNavGraph
 import com.daedan.festabook.presentation.setting.SettingViewModel
 import com.daedan.festabook.presentation.setting.navigation.settingNavGraph
-import com.daedan.festabook.presentation.splash.AppVersionManager
-import com.daedan.festabook.presentation.splash.SplashViewModel
-import com.daedan.festabook.presentation.splash.navigation.splashNavGraph
 import com.naver.maps.map.util.FusedLocationSource
 
 @Composable
@@ -54,27 +48,24 @@ fun MainScreen(
     logger: DefaultFirebaseLogger,
     locationSource: FusedLocationSource,
     placeDetailViewModelFactory: PlaceDetailViewModel.Factory,
-    appVersionManager: AppVersionManager,
     onAppFinish: () -> Unit,
     onSubscriptionConfirm: () -> Unit,
+    festabookNavigator: FestabookNavigator,
+    mainViewModel: MainViewModel,
+    homeViewModel: HomeViewModel,
+    scheduleViewModel: ScheduleViewModel,
+    placeMapViewModel: PlaceMapViewModel,
+    newsViewModel: NewsViewModel,
+    settingViewModel: SettingViewModel,
     modifier: Modifier = Modifier,
-    mainViewModel: MainViewModel = viewModel(),
-    homeViewModel: HomeViewModel = viewModel(),
-    scheduleViewModel: ScheduleViewModel = viewModel(),
-    placeMapViewModel: PlaceMapViewModel = viewModel(),
-    newsViewModel: NewsViewModel = viewModel(),
-    settingViewModel: SettingViewModel = viewModel(),
-    splashViewModel: SplashViewModel = viewModel(),
-    exploreViewModel: ExploreViewModel = viewModel(),
 ) {
-    val navigator = rememberFestabookNavigator()
+    val mainNavigator = rememberFestabookNavigator(MainTabRoute.Home)
     val snackbarHostState = remember { SnackbarHostState() }
     val snackbarManager = rememberAppSnackbarManager(snackbarHostState)
     val backPressExitMessage = stringResource(R.string.back_press_exit_message)
-    val noticeEnabledMessage = stringResource(R.string.setting_notice_enabled)
 
     ObserveAsEvents(flow = mainViewModel.navigateNewsEvent) {
-        navigator.navigateToMainTab(FestabookMainTab.NEWS)
+        mainNavigator.navigateToMainTab(FestabookMainTab.NEWS)
     }
     ObserveAsEvents(flow = mainViewModel.backPressEvent) { isDoublePress ->
         if (isDoublePress) {
@@ -84,7 +75,7 @@ fun MainScreen(
         }
     }
     ObserveAsEvents(flow = homeViewModel.navigateToScheduleEvent) {
-        navigator.navigateToMainTab(FestabookMainTab.SCHEDULE)
+        mainNavigator.navigateToMainTab(FestabookMainTab.SCHEDULE)
     }
 
     BackHandler {
@@ -97,10 +88,10 @@ fun MainScreen(
             }
         },
         bottomBar = {
-            if (navigator.shouldShowBottomBar) {
+            if (mainNavigator.shouldShowBottomBar) {
                 FestabookBottomNavigationBar(
-                    currentTab = navigator.currentTab,
-                    onTabSelect = { navigator.navigateToMainTab(it) },
+                    currentTab = mainNavigator.currentTab,
+                    onTabSelect = { mainNavigator.navigateToMainTab(it) },
                     onTabReSelect = { tab ->
                         when (tab) {
                             FestabookMainTab.SCHEDULE -> {
@@ -122,7 +113,7 @@ fun MainScreen(
         },
         modifier = modifier,
     ) { innerPadding ->
-        val isVisible = navigator.currentTab == FestabookMainTab.PLACE_MAP
+        val isVisible = mainNavigator.currentTab == FestabookMainTab.PLACE_MAP
         PlaceMapRoute(
             modifier =
                 Modifier
@@ -145,7 +136,7 @@ fun MainScreen(
             logger = logger,
             onShowErrorSnackBar = snackbarManager::showError,
             onStartPlaceDetail = {
-                navigator.navigate(
+                mainNavigator.navigate(
                     FestabookRoute.PlaceDetail(
                         placeDetailUiModel = it.placeDetail.value,
                     ),
@@ -154,19 +145,17 @@ fun MainScreen(
         )
         FestabookNavHost(
             modifier = Modifier.padding(innerPadding),
-            navigator = navigator,
+            festabookNavigator = festabookNavigator,
+            navigator = mainNavigator,
             mainViewModel = mainViewModel,
             homeViewModel = homeViewModel,
             scheduleViewModel = scheduleViewModel,
+            settingViewModel = settingViewModel,
             placeDetailViewModelFactory = placeDetailViewModelFactory,
             newsViewModel = newsViewModel,
-            settingViewModel = settingViewModel,
             notificationPermissionManager = notificationPermissionManager,
             onSubscriptionConfirm = onSubscriptionConfirm,
             snackbarManager = snackbarManager,
-            splashViewModel = splashViewModel,
-            exploreViewModel = exploreViewModel,
-            appVersionManager = appVersionManager,
         )
     }
 }
@@ -174,18 +163,16 @@ fun MainScreen(
 @Composable
 private fun FestabookNavHost(
     navigator: FestabookNavigator,
+    festabookNavigator: FestabookNavigator,
     mainViewModel: MainViewModel,
     homeViewModel: HomeViewModel,
     scheduleViewModel: ScheduleViewModel,
     placeDetailViewModelFactory: PlaceDetailViewModel.Factory,
     newsViewModel: NewsViewModel,
     settingViewModel: SettingViewModel,
-    splashViewModel: SplashViewModel,
-    exploreViewModel: ExploreViewModel,
     notificationPermissionManager: NotificationPermissionManager,
     onSubscriptionConfirm: () -> Unit,
     snackbarManager: SnackbarManager,
-    appVersionManager: AppVersionManager,
     modifier: Modifier = Modifier,
 ) {
     NavHost(
@@ -193,22 +180,10 @@ private fun FestabookNavHost(
         startDestination = navigator.startRoute,
         navController = navigator.navController,
     ) {
-        splashNavGraph(
-            viewModel = splashViewModel,
-            appVersionManager = appVersionManager,
-            onNavigateToExplore = { navigator.navigate(FestabookRoute.Explore) },
-            onNavigateToMain = { navigator.navigate(MainTabRoute.Home) },
-            onFinishApp = { navigator.popBackStack() },
-        )
-        exploreNavGraph(
-            viewModel = exploreViewModel,
-            onBackClick = { navigator.popBackStack() },
-            onNavigateToMain = { navigator.navigate(MainTabRoute.Home) },
-        )
         homeNavGraph(
             viewModel = homeViewModel,
             mainViewModel = mainViewModel,
-            onNavigateToExplore = { navigator.navigate(FestabookRoute.Explore) },
+            onNavigateToExplore = { festabookNavigator.navigate(FestabookRoute.Explore) },
             onSubscriptionConfirm = onSubscriptionConfirm,
             onShowErrorSnackbar = snackbarManager::showError,
         )

--- a/app/src/main/java/com/daedan/festabook/presentation/main/component/MainScreen.kt
+++ b/app/src/main/java/com/daedan/festabook/presentation/main/component/MainScreen.kt
@@ -39,6 +39,9 @@ import com.daedan.festabook.presentation.schedule.ScheduleViewModel
 import com.daedan.festabook.presentation.schedule.navigation.scheduleNavGraph
 import com.daedan.festabook.presentation.setting.SettingViewModel
 import com.daedan.festabook.presentation.setting.navigation.settingNavGraph
+import com.daedan.festabook.presentation.splash.AppVersionManager
+import com.daedan.festabook.presentation.splash.SplashViewModel
+import com.daedan.festabook.presentation.splash.navigation.splashNavGraph
 import com.naver.maps.map.util.FusedLocationSource
 
 @Composable
@@ -48,6 +51,7 @@ fun MainScreen(
     logger: DefaultFirebaseLogger,
     locationSource: FusedLocationSource,
     placeDetailViewModelFactory: PlaceDetailViewModel.Factory,
+    appVersionManager: AppVersionManager,
     onAppFinish: () -> Unit,
     onSubscriptionConfirm: () -> Unit,
     onNavigateToExplore: () -> Unit, // TODO 검색화면 마이그레이션 시 제거
@@ -58,6 +62,7 @@ fun MainScreen(
     placeMapViewModel: PlaceMapViewModel = viewModel(),
     newsViewModel: NewsViewModel = viewModel(),
     settingViewModel: SettingViewModel = viewModel(),
+    splashViewModel: SplashViewModel = viewModel(),
 ) {
     val navigator = rememberFestabookNavigator()
     val snackbarHostState = remember { SnackbarHostState() }
@@ -157,6 +162,8 @@ fun MainScreen(
             onNavigateToExplore = onNavigateToExplore,
             onSubscriptionConfirm = onSubscriptionConfirm,
             snackbarManager = snackbarManager,
+            splashViewModel = splashViewModel,
+            appVersionManager = appVersionManager,
         )
     }
 }
@@ -170,10 +177,12 @@ private fun FestabookNavHost(
     placeDetailViewModelFactory: PlaceDetailViewModel.Factory,
     newsViewModel: NewsViewModel,
     settingViewModel: SettingViewModel,
+    splashViewModel: SplashViewModel,
     notificationPermissionManager: NotificationPermissionManager,
     onNavigateToExplore: () -> Unit,
     onSubscriptionConfirm: () -> Unit,
     snackbarManager: SnackbarManager,
+    appVersionManager: AppVersionManager,
     modifier: Modifier = Modifier,
 ) {
     NavHost(
@@ -181,6 +190,13 @@ private fun FestabookNavHost(
         startDestination = navigator.startRoute,
         navController = navigator.navController,
     ) {
+        splashNavGraph(
+            viewModel = splashViewModel,
+            appVersionManager = appVersionManager,
+            onNavigateToExplore = { navigator.navigate(FestabookRoute.Explore) },
+            onNavigateToMain = { navigator.navigateToMainTab(FestabookMainTab.HOME) },
+            onFinishApp = { navigator.popBackStack() },
+        )
         homeNavGraph(
             viewModel = homeViewModel,
             mainViewModel = mainViewModel,

--- a/app/src/main/java/com/daedan/festabook/presentation/main/component/MainScreen.kt
+++ b/app/src/main/java/com/daedan/festabook/presentation/main/component/MainScreen.kt
@@ -21,11 +21,14 @@ import com.daedan.festabook.presentation.common.ObserveAsEvents
 import com.daedan.festabook.presentation.common.component.FestabookSnackbar
 import com.daedan.festabook.presentation.common.component.SnackbarManager
 import com.daedan.festabook.presentation.common.component.rememberAppSnackbarManager
+import com.daedan.festabook.presentation.explore.ExploreViewModel
+import com.daedan.festabook.presentation.explore.navigation.exploreNavGraph
 import com.daedan.festabook.presentation.home.HomeViewModel
 import com.daedan.festabook.presentation.home.navigation.homeNavGraph
 import com.daedan.festabook.presentation.main.FestabookMainTab
 import com.daedan.festabook.presentation.main.FestabookNavigator
 import com.daedan.festabook.presentation.main.FestabookRoute
+import com.daedan.festabook.presentation.main.MainTabRoute
 import com.daedan.festabook.presentation.main.MainViewModel
 import com.daedan.festabook.presentation.main.rememberFestabookNavigator
 import com.daedan.festabook.presentation.news.NewsViewModel
@@ -54,7 +57,6 @@ fun MainScreen(
     appVersionManager: AppVersionManager,
     onAppFinish: () -> Unit,
     onSubscriptionConfirm: () -> Unit,
-    onNavigateToExplore: () -> Unit, // TODO 검색화면 마이그레이션 시 제거
     modifier: Modifier = Modifier,
     mainViewModel: MainViewModel = viewModel(),
     homeViewModel: HomeViewModel = viewModel(),
@@ -63,6 +65,7 @@ fun MainScreen(
     newsViewModel: NewsViewModel = viewModel(),
     settingViewModel: SettingViewModel = viewModel(),
     splashViewModel: SplashViewModel = viewModel(),
+    exploreViewModel: ExploreViewModel = viewModel(),
 ) {
     val navigator = rememberFestabookNavigator()
     val snackbarHostState = remember { SnackbarHostState() }
@@ -159,10 +162,10 @@ fun MainScreen(
             newsViewModel = newsViewModel,
             settingViewModel = settingViewModel,
             notificationPermissionManager = notificationPermissionManager,
-            onNavigateToExplore = onNavigateToExplore,
             onSubscriptionConfirm = onSubscriptionConfirm,
             snackbarManager = snackbarManager,
             splashViewModel = splashViewModel,
+            exploreViewModel = exploreViewModel,
             appVersionManager = appVersionManager,
         )
     }
@@ -178,8 +181,8 @@ private fun FestabookNavHost(
     newsViewModel: NewsViewModel,
     settingViewModel: SettingViewModel,
     splashViewModel: SplashViewModel,
+    exploreViewModel: ExploreViewModel,
     notificationPermissionManager: NotificationPermissionManager,
-    onNavigateToExplore: () -> Unit,
     onSubscriptionConfirm: () -> Unit,
     snackbarManager: SnackbarManager,
     appVersionManager: AppVersionManager,
@@ -194,13 +197,18 @@ private fun FestabookNavHost(
             viewModel = splashViewModel,
             appVersionManager = appVersionManager,
             onNavigateToExplore = { navigator.navigate(FestabookRoute.Explore) },
-            onNavigateToMain = { navigator.navigateToMainTab(FestabookMainTab.HOME) },
+            onNavigateToMain = { navigator.navigate(MainTabRoute.Home) },
             onFinishApp = { navigator.popBackStack() },
+        )
+        exploreNavGraph(
+            viewModel = exploreViewModel,
+            onBackClick = { navigator.popBackStack() },
+            onNavigateToMain = { navigator.navigate(MainTabRoute.Home) },
         )
         homeNavGraph(
             viewModel = homeViewModel,
             mainViewModel = mainViewModel,
-            onNavigateToExplore = onNavigateToExplore,
+            onNavigateToExplore = { navigator.navigate(FestabookRoute.Explore) },
             onSubscriptionConfirm = onSubscriptionConfirm,
             onShowErrorSnackbar = snackbarManager::showError,
         )

--- a/app/src/main/java/com/daedan/festabook/presentation/main/navigation/MainNavigation.kt
+++ b/app/src/main/java/com/daedan/festabook/presentation/main/navigation/MainNavigation.kt
@@ -1,0 +1,43 @@
+package com.daedan.festabook.presentation.main.navigation
+
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.compose.composable
+import com.daedan.festabook.logging.DefaultFirebaseLogger
+import com.daedan.festabook.presentation.NotificationPermissionManager
+import com.daedan.festabook.presentation.main.FestabookNavigator
+import com.daedan.festabook.presentation.main.FestabookRoute
+import com.daedan.festabook.presentation.main.component.MainScreen
+import com.daedan.festabook.presentation.placeDetail.PlaceDetailViewModel
+import com.naver.maps.map.util.FusedLocationSource
+
+fun NavGraphBuilder.mainNavGraph(
+    defaultViewModelFactory: ViewModelProvider.Factory,
+    placeDetailViewModelFactory: PlaceDetailViewModel.Factory,
+    notificationPermissionManager: NotificationPermissionManager,
+    locationSource: FusedLocationSource,
+    logger: DefaultFirebaseLogger,
+    onSubscriptionConfirm: () -> Unit,
+    festabookNavigator: FestabookNavigator,
+) {
+    composable<FestabookRoute.Main> {
+        val mainBackEntry =
+            festabookNavigator.navController.getBackStackEntry<FestabookRoute.Main>()
+        MainScreen(
+            notificationPermissionManager = notificationPermissionManager,
+            logger = logger,
+            locationSource = locationSource,
+            placeDetailViewModelFactory = placeDetailViewModelFactory,
+            onAppFinish = festabookNavigator::popBackStack,
+            onSubscriptionConfirm = onSubscriptionConfirm,
+            festabookNavigator = festabookNavigator,
+            mainViewModel = viewModel(mainBackEntry, factory = defaultViewModelFactory),
+            homeViewModel = viewModel(mainBackEntry, factory = defaultViewModelFactory),
+            scheduleViewModel = viewModel(mainBackEntry, factory = defaultViewModelFactory),
+            placeMapViewModel = viewModel(mainBackEntry, factory = defaultViewModelFactory),
+            newsViewModel = viewModel(mainBackEntry, factory = defaultViewModelFactory),
+            settingViewModel = viewModel(mainBackEntry, factory = defaultViewModelFactory),
+        )
+    }
+}

--- a/app/src/main/java/com/daedan/festabook/presentation/main/navigation/MainNavigation.kt
+++ b/app/src/main/java/com/daedan/festabook/presentation/main/navigation/MainNavigation.kt
@@ -10,6 +10,7 @@ import com.daedan.festabook.presentation.main.FestabookNavigator
 import com.daedan.festabook.presentation.main.FestabookRoute
 import com.daedan.festabook.presentation.main.component.MainScreen
 import com.daedan.festabook.presentation.placeDetail.PlaceDetailViewModel
+import com.daedan.festabook.presentation.setting.SettingViewModel
 import com.naver.maps.map.util.FusedLocationSource
 
 fun NavGraphBuilder.mainNavGraph(
@@ -20,6 +21,7 @@ fun NavGraphBuilder.mainNavGraph(
     logger: DefaultFirebaseLogger,
     onSubscriptionConfirm: () -> Unit,
     festabookNavigator: FestabookNavigator,
+    settingViewModel: SettingViewModel,
 ) {
     composable<FestabookRoute.Main> {
         val mainBackEntry =
@@ -37,7 +39,7 @@ fun NavGraphBuilder.mainNavGraph(
             scheduleViewModel = viewModel(mainBackEntry, factory = defaultViewModelFactory),
             placeMapViewModel = viewModel(mainBackEntry, factory = defaultViewModelFactory),
             newsViewModel = viewModel(mainBackEntry, factory = defaultViewModelFactory),
-            settingViewModel = viewModel(mainBackEntry, factory = defaultViewModelFactory),
+            settingViewModel = settingViewModel,
         )
     }
 }

--- a/app/src/main/java/com/daedan/festabook/presentation/main/navigation/MainNavigation.kt
+++ b/app/src/main/java/com/daedan/festabook/presentation/main/navigation/MainNavigation.kt
@@ -8,7 +8,9 @@ import com.daedan.festabook.logging.DefaultFirebaseLogger
 import com.daedan.festabook.presentation.NotificationPermissionManager
 import com.daedan.festabook.presentation.main.FestabookNavigator
 import com.daedan.festabook.presentation.main.FestabookRoute
+import com.daedan.festabook.presentation.main.MainViewModel
 import com.daedan.festabook.presentation.main.component.MainScreen
+import com.daedan.festabook.presentation.news.NewsViewModel
 import com.daedan.festabook.presentation.placeDetail.PlaceDetailViewModel
 import com.daedan.festabook.presentation.setting.SettingViewModel
 import com.naver.maps.map.util.FusedLocationSource
@@ -22,6 +24,8 @@ fun NavGraphBuilder.mainNavGraph(
     onSubscriptionConfirm: () -> Unit,
     festabookNavigator: FestabookNavigator,
     settingViewModel: SettingViewModel,
+    mainViewModel: MainViewModel,
+    newsViewModel: NewsViewModel,
 ) {
     composable<FestabookRoute.Main> {
         val mainBackEntry =
@@ -34,12 +38,12 @@ fun NavGraphBuilder.mainNavGraph(
             onAppFinish = festabookNavigator::popBackStack,
             onSubscriptionConfirm = onSubscriptionConfirm,
             festabookNavigator = festabookNavigator,
-            mainViewModel = viewModel(mainBackEntry, factory = defaultViewModelFactory),
             homeViewModel = viewModel(mainBackEntry, factory = defaultViewModelFactory),
             scheduleViewModel = viewModel(mainBackEntry, factory = defaultViewModelFactory),
             placeMapViewModel = viewModel(mainBackEntry, factory = defaultViewModelFactory),
-            newsViewModel = viewModel(mainBackEntry, factory = defaultViewModelFactory),
             settingViewModel = settingViewModel,
+            mainViewModel = mainViewModel,
+            newsViewModel = newsViewModel,
         )
     }
 }

--- a/app/src/main/java/com/daedan/festabook/presentation/splash/component/SplashScreen.kt
+++ b/app/src/main/java/com/daedan/festabook/presentation/splash/component/SplashScreen.kt
@@ -1,0 +1,59 @@
+package com.daedan.festabook.presentation.splash.component
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.daedan.festabook.presentation.splash.AppVersionManager
+import com.daedan.festabook.presentation.splash.SplashUiState
+import com.daedan.festabook.presentation.splash.SplashViewModel
+
+@Composable
+fun SplashScreen(
+    viewModel: SplashViewModel,
+    appVersionManager: AppVersionManager,
+    onNavigateToExplore: () -> Unit,
+    onNavigateToMain: (Long) -> Unit,
+    onFinishApp: () -> Unit,
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val currentOnNavigateToMain by rememberUpdatedState(onNavigateToMain)
+    val currentOnNavigateToExplore by rememberUpdatedState(onNavigateToExplore)
+
+    LaunchedEffect(Unit) {
+        // 앱 실행 시 즉시 앱 버전 업데이트의 필요 유무 확인
+        val result = appVersionManager.getIsAppUpdateAvailable()
+        viewModel.handleVersionCheckResult(result)
+    }
+
+    LaunchedEffect(uiState) {
+        when (val state = uiState) {
+            is SplashUiState.NavigateToExplore -> {
+                currentOnNavigateToExplore()
+            }
+
+            is SplashUiState.NavigateToMain -> {
+                currentOnNavigateToMain(state.festivalId)
+            }
+
+            else -> {}
+        }
+    }
+
+    when (uiState) {
+        is SplashUiState.ShowUpdateDialog -> {
+            UpdateDialog(
+                onConfirm = { appVersionManager.updateApp() },
+            )
+        }
+
+        is SplashUiState.ShowNetworkErrorDialog -> {
+            NetworkErrorDialog(
+                onConfirm = onFinishApp,
+            )
+        }
+
+        else -> {}
+    }
+}

--- a/app/src/main/java/com/daedan/festabook/presentation/splash/navigation/SplashNavigation.kt
+++ b/app/src/main/java/com/daedan/festabook/presentation/splash/navigation/SplashNavigation.kt
@@ -1,0 +1,26 @@
+package com.daedan.festabook.presentation.splash.navigation
+
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.compose.composable
+import com.daedan.festabook.presentation.main.FestabookRoute
+import com.daedan.festabook.presentation.splash.AppVersionManager
+import com.daedan.festabook.presentation.splash.SplashViewModel
+import com.daedan.festabook.presentation.splash.component.SplashScreen
+
+fun NavGraphBuilder.splashNavGraph(
+    viewModel: SplashViewModel,
+    appVersionManager: AppVersionManager,
+    onNavigateToExplore: () -> Unit,
+    onNavigateToMain: (Long) -> Unit,
+    onFinishApp: () -> Unit,
+) {
+    composable<FestabookRoute.Splash> {
+        SplashScreen(
+            viewModel = viewModel,
+            appVersionManager = appVersionManager,
+            onNavigateToExplore = onNavigateToExplore,
+            onNavigateToMain = onNavigateToMain,
+            onFinishApp = onFinishApp,
+        )
+    }
+}


### PR DESCRIPTION
## #️⃣ 이슈 번호

> https://github.com/festabook/android/issues/56

<br>

## 🛠️ 작업 내용

- Splash, Explore를 Main과 연동했습니다. 

<br>

## 🙇🏻 중점 리뷰 요청

기존에는 SplashActivity, ExploreActivity로 인해 자연스럽게 ViewModel의 생명주기가 해결되었습니다. 
하지만 이제는 MainActivity 하나만 남게 되었습니다. 
이는 MainActivity가 ExploreActivity의 역할까지 수행한다는 의미입니다. 

문제는 ExploreActivity는 축제 검색 전의 상태를 가집니다. 
이는 구현 난이도를 급상승하는 원인이 됩니다. 

### 문제 상황들
1.  축제 검색 전의 상태지만, 축제 검색 후 생성되어야 하는 뷰모델을 참조해야 합니다. ExploreActivity가 homeViewModel, placeMapViewModel를 참조한다고 생각하면 좋을 것 같습니다. 
2. PlaceMapRoute는 API 효율 상, MainScreen에서 계속 메모리에 남아있어야 합니다. 하지만 PlaceMapRoute 또한 축제 검색 후 생겨나야 하기 때문에 이제는 전역에서 참조하기 어렵습니다. 
3. Scaffold의 bottomBar에 scheduleViewModel, PlaceMapViewModel을 참조합니다. 이는 1번과 같은 문제를 일으킵니다. 
4. MainAcitivity에서 fcm, 권한 설정의 이유로 settingViewModel, newsViewModel을 사용합니다. 마찬가지로 1반과 같은 문제를 일으킵니다. 
5. ExploreScreen로 진입하면 MainScreen에서 생성한 viewModel을 날린 후 재생성 후, 특정 컴포저블 함수를 꼭 실행해야 합니다. 하지만 ComposeNavigation에는 중첩 navigation에서 composable 사용이 불가능합니다. 

이런 문제로 인해 상당한 시간이 소요되었습니다. 

제가 생각한 아키텍쳐는 다음과 같습니다.
1. 중첩 NavHost **(현재 구현)** 이는 MainScreen 상위의 Screen을 두어서 가장 깔끔하게 해결할 수 있습니다. 
다만 가장 큰 문제가 navController가 여러 개가 생길 수 있어, 복잡한 화면으로 구현 시, 관리가 매우 까다로워 질 수 있습니다. (단일 진실 공급원 위반) 

다만 MainScreen과 FestabookScreen을 별개의 **모듈** 로 생각한다면 조금 납득 가능한 구현이라고 생각하여,  이 방식을 채택했습니다.

2. 단일 NavHost, Screen에 가시성 추가
예를 들어 기존 MainScreen에서 수행한 초기화 로직(컴포저블 함수)을 **축제 검색 완료 후의 상태일때만** 수행하도록 가시성을 제한합니다. navController가 하나가 되는 장점은 있지만, 반대로 코드의 불필요한 depth가 증가하고, **가시성을 변경** 하는 것이기 때문에 viewModel 생명주기의 문제가 남아있습니다. 

3. ViewModel의 init을 public으로 만들기
만약 ViewModel이 100개가 생기면 100개의 뷰모델을 모두 로딩한 후, 데이터만 갈아끼는 방법입니다. 가장 간단하지만 메모리를 비효율적으로 쓰는 것 같으며, FIle Changes가 늘어나기에 기각했습니다


이외에도 다른 좋은 방법이 있다면 공유 부탁드립니다!!


<br>

## 📸 이미지 첨부 (Optional)

<img src="파일주소" width="50%" height="50%"/>
