### PR TITLE
[Fix] 타임태그가 없을 때에도 상세페이지 클릭되도록 변경

### DIFF
--- a/app/src/main/java/com/daedan/festabook/presentation/placeMap/intent/handler/SelectEventHandler.kt
+++ b/app/src/main/java/com/daedan/festabook/presentation/placeMap/intent/handler/SelectEventHandler.kt
@@ -63,9 +63,7 @@ class SelectEventHandler(
             is SelectEvent.OnPlacePreviewClick -> {
                 val selectedTimeTag = uiState.value.selectedTimeTag
                 val selectedPlace = event.place
-                if (selectedPlace is LoadState.Success &&
-                    selectedTimeTag is LoadState.Success
-                ) {
+                if (selectedPlace is LoadState.Success) {
                     context.scope.launch {
                         context.placeMapSideEffect.send(PlaceMapSideEffect.StartPlaceDetail(event.place))
                         logger.log(
@@ -74,7 +72,10 @@ class SelectEventHandler(
                                 placeName =
                                     selectedPlace.value.place.title
                                         ?: "undefined",
-                                timeTag = selectedTimeTag.value.name,
+                                timeTag =
+                                    (selectedTimeTag as? LoadState.Success<TimeTag>)
+                                        ?.value
+                                        ?.name ?: "undefined",
                                 category = selectedPlace.value.place.category.name,
                             ),
                         )


### PR DESCRIPTION
## #️⃣ 이슈 번호

> https://github.com/festabook/android/issues/58

<br>

## 🛠️ 작업 내용
- 장소 미리보기 클릭(`OnPlacePreviewClick`) 이벤트 처리 시, 타임태그가 없는 축제일 경우에도 클릭이 되도록 수정했습니다
<br>

## 🙇🏻 중점 리뷰 요청

- 특히 확인이 필요한 부분, 고민했던 부분 등을 적어주세요.

<br>

## 📸 이미지 첨부 (Optional)

https://github.com/user-attachments/assets/52b4acac-8faf-4338-b333-0f9349ad9028


